### PR TITLE
feat(user): support MySQL dual password

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -28,6 +28,22 @@ resource "mysql_user" "test" {
   }
 }
 
+# rotate the password without downtime using MySQL dual password support
+# see https://dev.mysql.com/doc/refman/8.0/en/password-management.html#dual-passwords
+#
+# 1. change `auth_string` and apply with `retain_current_password = true`
+#    to keep the old password usable as the secondary password
+# 2. deploy the new password to your applications
+# 3. apply with `discard_old_password = true` to drop the old password
+resource "mysql_user" "rotating-user" {
+  name = "app-user"
+  host = "app.example.com"
+  auth_option {
+    auth_string             = "new-password"
+    retain_current_password = true
+  }
+}
+
 # use RDS IAM DB Auth
 # see https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.IAMDBAuth.html
 resource "mysql_user" "rds-user" {
@@ -61,8 +77,10 @@ resource "mysql_user" "rds-user" {
 Optional:
 
 - `auth_string` (String) Plain text password. Conflicts with `random_password`.
+- `discard_old_password` (Boolean) Discard the secondary password. Requires MySQL 8.0.14 or later. See MySQL Reference Manual [8.2.15 Password Management](https://dev.mysql.com/doc/refman/8.0/en/password-management.html#dual-passwords) for more details. This option is ignored when creating a user because a new user has no secondary password. Cannot be true at the same time as `retain_current_password`.
 - `plugin` (String) An authentication plugin name. See MySQL Reference Manual [6.4.1 Authentication Plugins](https://dev.mysql.com/doc/refman/8.0/en/authentication-plugins.html) for more details. Conflicts with `auth_string`, `random_password` if set `AWSAuthenticationPlugin`.
 - `random_password` (Boolean) Generate random password when create user. Display generated password after creating user. Conflicts with `auth_string`.
+- `retain_current_password` (Boolean) Keep the current password as the secondary password when changing the password. Requires MySQL 8.0.14 or later. See MySQL Reference Manual [8.2.15 Password Management](https://dev.mysql.com/doc/refman/8.0/en/password-management.html#dual-passwords) for more details. This option is ignored when creating a user because `CREATE USER` does not accept `RETAIN CURRENT PASSWORD`. Cannot be true at the same time as `discard_old_password`.
 
 ## Import
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -42,7 +42,7 @@ resource "mysql_user" "test" {
 # step 3 is mandatory. removing `retain_current_password` does not discard the old
 # password, so skipping it leaves the old password valid forever
 resource "mysql_user" "rotating-user" {
-  name = "app-user"
+  name = "rotating-app-user"
   host = "app.example.com"
   auth_option {
     auth_string             = "new-password"

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -6,6 +6,7 @@ description: |-
   The mysql_user resource creates and manages a user on a MySQL server.
   ~> Note: The password for the user is provided in plain text, and is obscured by an unsalted hash in the state Read more about sensitive data in state https://www.terraform.io/language/state/sensitive-data. Care is required when using this resource, to avoid disclosing the password.
   ~> Note about random password: The generated random password will be shown in the log immediately after running terraform apply. Be sure to save the password, as there is no way to check it after that.
+  !> Warning about dual password: discard_old_password is the only way to invalidate a password retained by retain_current_password. Removing retain_current_password from the configuration is not equivalent to discarding it, because MySQL keeps the secondary password until DISCARD OLD PASSWORD is issued. An abandoned rotation therefore leaves the old password valid forever. Use has_secondary_password to detect an account which still has a secondary password.
 ---
 
 # mysql_user (Resource)
@@ -15,6 +16,8 @@ The `mysql_user` resource creates and manages a user on a MySQL server.
 ~> **Note:** The password for the user is provided in plain text, and is obscured by an unsalted hash in the state [Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data). Care is required when using this resource, to avoid disclosing the password.
 
 ~> **Note about random password:** The generated random password will be shown in the log immediately after running `terraform apply`. Be sure to save the password, as there is no way to check it after that.
+
+!> **Warning about dual password:** `discard_old_password` is the only way to invalidate a password retained by `retain_current_password`. Removing `retain_current_password` from the configuration is **not** equivalent to discarding it, because MySQL keeps the secondary password until `DISCARD OLD PASSWORD` is issued. An abandoned rotation therefore leaves the old password valid forever. Use `has_secondary_password` to detect an account which still has a secondary password.
 
 ## Example Usage
 
@@ -35,12 +38,25 @@ resource "mysql_user" "test" {
 #    to keep the old password usable as the secondary password
 # 2. deploy the new password to your applications
 # 3. apply with `discard_old_password = true` to drop the old password
+#
+# step 3 is mandatory. removing `retain_current_password` does not discard the old
+# password, so skipping it leaves the old password valid forever
 resource "mysql_user" "rotating-user" {
   name = "app-user"
   host = "app.example.com"
   auth_option {
     auth_string             = "new-password"
     retain_current_password = true
+  }
+}
+
+# warn while an account still has a secondary password, so that a rotation which was
+# never finished with `discard_old_password` does not go unnoticed
+# `check` requires Terraform 1.5 or later. use an output instead on an earlier version
+check "no_stale_secondary_password" {
+  assert {
+    condition     = !mysql_user.rotating-user.has_secondary_password
+    error_message = "${mysql_user.rotating-user.id} still has a secondary password. Apply with discard_old_password = true once every consumer uses the new password."
   }
 }
 
@@ -69,6 +85,7 @@ resource "mysql_user" "rds-user" {
 
 ### Read-Only
 
+- `has_secondary_password` (Boolean) Whether the account currently has a secondary password, read from `mysql.user.User_attributes`. Unlike `retain_current_password` and `discard_old_password`, which are write-only options for `ALTER USER`, this reports the state of the account on the server, so it can be used to detect a rotation which was never finished with `discard_old_password`. Always `false` on MySQL earlier than 8.0.14, which has no dual password support.
 - `id` (String) The identifier
 
 <a id="nestedblock--auth_option"></a>

--- a/examples/resources/mysql_user/resource.tf
+++ b/examples/resources/mysql_user/resource.tf
@@ -18,7 +18,7 @@ resource "mysql_user" "test" {
 # step 3 is mandatory. removing `retain_current_password` does not discard the old
 # password, so skipping it leaves the old password valid forever
 resource "mysql_user" "rotating-user" {
-  name = "app-user"
+  name = "rotating-app-user"
   host = "app.example.com"
   auth_option {
     auth_string             = "new-password"

--- a/examples/resources/mysql_user/resource.tf
+++ b/examples/resources/mysql_user/resource.tf
@@ -7,6 +7,22 @@ resource "mysql_user" "test" {
   }
 }
 
+# rotate the password without downtime using MySQL dual password support
+# see https://dev.mysql.com/doc/refman/8.0/en/password-management.html#dual-passwords
+#
+# 1. change `auth_string` and apply with `retain_current_password = true`
+#    to keep the old password usable as the secondary password
+# 2. deploy the new password to your applications
+# 3. apply with `discard_old_password = true` to drop the old password
+resource "mysql_user" "rotating-user" {
+  name = "app-user"
+  host = "app.example.com"
+  auth_option {
+    auth_string             = "new-password"
+    retain_current_password = true
+  }
+}
+
 # use RDS IAM DB Auth
 # see https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.IAMDBAuth.html
 resource "mysql_user" "rds-user" {

--- a/examples/resources/mysql_user/resource.tf
+++ b/examples/resources/mysql_user/resource.tf
@@ -14,12 +14,25 @@ resource "mysql_user" "test" {
 #    to keep the old password usable as the secondary password
 # 2. deploy the new password to your applications
 # 3. apply with `discard_old_password = true` to drop the old password
+#
+# step 3 is mandatory. removing `retain_current_password` does not discard the old
+# password, so skipping it leaves the old password valid forever
 resource "mysql_user" "rotating-user" {
   name = "app-user"
   host = "app.example.com"
   auth_option {
     auth_string             = "new-password"
     retain_current_password = true
+  }
+}
+
+# warn while an account still has a secondary password, so that a rotation which was
+# never finished with `discard_old_password` does not go unnoticed
+# `check` requires Terraform 1.5 or later. use an output instead on an earlier version
+check "no_stale_secondary_password" {
+  assert {
+    condition     = !mysql_user.rotating-user.has_secondary_password
+    error_message = "${mysql_user.rotating-user.id} still has a secondary password. Apply with discard_old_password = true once every consumer uses the new password."
   }
 }
 

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -50,6 +50,17 @@ func supportsDualPassword(currentVersion *version.Version) bool {
 	return !currentVersion.Core().LessThan(dualPasswordMinVersion)
 }
 
+// secondaryPasswordExpression returns the SQL expression reporting whether an account has a
+// secondary password. `mysql.user.User_attributes` exists only from MySQL 8.0.14, the version
+// which added dual password, so an earlier server never has a secondary password and the column
+// must not be referenced at all to avoid ER_BAD_FIELD_ERROR.
+func secondaryPasswordExpression(currentVersion *version.Version) string {
+	if !supportsDualPassword(currentVersion) {
+		return `FALSE`
+	}
+	return `JSON_CONTAINS_PATH(User_attributes, 'one', '$.additional_password') IS TRUE`
+}
+
 // checkDualPasswordSupport reports a clear error instead of letting MySQL fail with a syntax error.
 // `serverVersion` is also called on connecting to MySQL, so it does not add a new failure mode.
 func checkDualPasswordSupport(db *sql.DB) error {
@@ -74,11 +85,12 @@ type UserResource struct {
 
 // UserResourceModel describes the resource data model.
 type UserResourceModel struct {
-	ID         types.String `tfsdk:"id"`
-	Name       types.String `tfsdk:"name"`
-	Host       types.String `tfsdk:"host"`
-	Lock       types.Bool   `tfsdk:"lock"`
-	AuthOption types.Object `tfsdk:"auth_option"`
+	ID                   types.String `tfsdk:"id"`
+	Name                 types.String `tfsdk:"name"`
+	Host                 types.String `tfsdk:"host"`
+	Lock                 types.Bool   `tfsdk:"lock"`
+	HasSecondaryPassword types.Bool   `tfsdk:"has_secondary_password"`
+	AuthOption           types.Object `tfsdk:"auth_option"`
 }
 
 type AuthOptionModel struct {
@@ -109,7 +121,12 @@ func (r *UserResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 			"state [Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data). " +
 			"Care is required when using this resource, to avoid disclosing the password.\n\n" +
 			"~> **Note about random password:** The generated random password will be shown in the log immediately after running `terraform apply`. " +
-			"Be sure to save the password, as there is no way to check it after that.",
+			"Be sure to save the password, as there is no way to check it after that.\n\n" +
+			"!> **Warning about dual password:** `discard_old_password` is the only way to invalidate a password retained by " +
+			"`retain_current_password`. Removing `retain_current_password` from the configuration is **not** equivalent to discarding it, " +
+			"because MySQL keeps the secondary password until `DISCARD OLD PASSWORD` is issued. " +
+			"An abandoned rotation therefore leaves the old password valid forever. " +
+			"Use `has_secondary_password` to detect an account which still has a secondary password.",
 		Attributes: map[string]schema.Attribute{
 			"id":   utils.IDAttribute(),
 			"name": utils.NameAttribute("user", true),
@@ -119,6 +136,13 @@ func (r *UserResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Optional:            true,
 				Computed:            true,
 				Default:             booldefault.StaticBool(false),
+			},
+			"has_secondary_password": schema.BoolAttribute{
+				MarkdownDescription: "Whether the account currently has a secondary password, read from `mysql.user.User_attributes`. " +
+					"Unlike `retain_current_password` and `discard_old_password`, which are write-only options for `ALTER USER`, " +
+					"this reports the state of the account on the server, so it can be used to detect a rotation which was never " +
+					"finished with `discard_old_password`. Always `false` on MySQL earlier than 8.0.14, which has no dual password support.",
+				Computed: true,
 			},
 		},
 		Blocks: map[string]schema.Block{
@@ -284,6 +308,8 @@ func (r *UserResource) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 
 	data.ID = types.StringValue(fmt.Sprintf("%s@%s", data.Name.ValueString(), data.Host.ValueString()))
+	// `CREATE USER` does not accept `RETAIN CURRENT PASSWORD`, so a new user never has one.
+	data.HasSecondaryPassword = types.BoolValue(false)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -292,6 +318,12 @@ func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	db, err := getDatabase(ctx, r.mysqlConfig)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to connect MySQL", err.Error())
+		return
+	}
+
+	currentVersion, err := getDatabaseVersion(ctx, r.mysqlConfig)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed getting the server version", err.Error())
 		return
 	}
 
@@ -307,27 +339,30 @@ func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	args = append(args, host)
 	args = append(args, user)
 
-	sql := `
+	sql := fmt.Sprintf(`
 SELECT
   Host
 , User
 , plugin
 , authentication_string
 , account_locked
+, %s
 FROM
    mysql.user
 WHERE
   Host = ?
   AND User = ?
-`
+`, secondaryPasswordExpression(currentVersion))
 	tflog.Info(ctx, sql, map[string]any{"args": args})
 	var _host, _user, plugin, authString, accountLocked string
-	if err = db.QueryRowContext(ctx, sql, args...).Scan(&_host, &_user, &plugin, &authString, &accountLocked); err != nil {
+	var hasSecondaryPassword bool
+	if err = db.QueryRowContext(ctx, sql, args...).Scan(&_host, &_user, &plugin, &authString, &accountLocked, &hasSecondaryPassword); err != nil {
 		resp.State.RemoveResource(ctx)
 		return
 	} else {
 		data.Name = types.StringValue(user)
 		data.Host = types.StringValue(host)
+		data.HasSecondaryPassword = types.BoolValue(hasSecondaryPassword)
 		data.Lock = types.BoolValue(accountLocked == "Y")
 
 		if data.AuthOption.IsNull() {
@@ -391,6 +426,12 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	db, err := getDatabase(ctx, r.mysqlConfig)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to connect MySQL", err.Error())
+		return
+	}
+
+	currentVersion, err := getDatabaseVersion(ctx, r.mysqlConfig)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed getting the server version", err.Error())
 		return
 	}
 
@@ -484,20 +525,59 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 			"The generated password is not saved in tfstate")
 	}
 	// `DISCARD OLD PASSWORD` cannot be combined with `IDENTIFIED BY` in a single statement.
+	var discardErr error
 	if discardOldPassword {
 		_ = rows.Close()
-		if err := alterUserDiscardOldPassword(ctx, db, data); err != nil {
-			// MySQL DDL is not transactional, so the `ALTER USER` above is already committed.
-			// Save the state to keep it in sync with the server before reporting the error.
-			partialState, diags := stateWithoutDiscardOldPassword(data)
-			resp.Diagnostics.Append(diags...)
-			resp.Diagnostics.Append(resp.State.Set(ctx, partialState)...)
-			resp.Diagnostics.AddError("Failed discarding old password", err.Error())
-			return
-		}
+		discardErr = alterUserDiscardOldPassword(ctx, db, data)
+	}
+
+	// The secondary password is read back because it survives a password change which does not
+	// specify `RETAIN CURRENT PASSWORD`, so it cannot be derived from this update alone.
+	if hasSecondaryPassword, err := readHasSecondaryPassword(ctx, db, currentVersion, data); err == nil {
+		data.HasSecondaryPassword = types.BoolValue(hasSecondaryPassword)
+	} else {
+		// Failing here would throw away the state although `ALTER USER` is already committed,
+		// which is the very thing saving the state below avoids. Keep the recorded value, which
+		// the next successful read corrects, and report the failure as a warning instead.
+		resp.Diagnostics.AddWarning(
+			"Could not read the secondary password state",
+			fmt.Sprintf("Keeping the value recorded in the state for `has_secondary_password`: %v", err))
+		// `ValueBool` turns the null of a state written before this attribute existed into false,
+		// which a condition such as `!has_secondary_password` would otherwise fail to evaluate.
+		data.HasSecondaryPassword = types.BoolValue(state.HasSecondaryPassword.ValueBool())
+	}
+
+	if discardErr != nil {
+		// MySQL DDL is not transactional, so the `ALTER USER` above is already committed.
+		// Save the state to keep it in sync with the server before reporting the error.
+		partialState, diags := stateWithoutDiscardOldPassword(data)
+		resp.Diagnostics.Append(diags...)
+		resp.Diagnostics.Append(resp.State.Set(ctx, partialState)...)
+		resp.Diagnostics.AddError("Failed discarding old password", discardErr.Error())
+		return
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// readHasSecondaryPassword reports whether the account currently has a secondary password.
+// `ALTER USER` does not report it, so it has to be read back after updating the user.
+func readHasSecondaryPassword(ctx context.Context, db *sql.DB, currentVersion *version.Version, data *UserResourceModel) (bool, error) {
+	if !supportsDualPassword(currentVersion) {
+		return false, nil
+	}
+
+	var args []interface{}
+	args = append(args, data.Name.ValueString())
+	args = append(args, data.Host.ValueString())
+
+	query := fmt.Sprintf(`SELECT %s FROM mysql.user WHERE User = ? AND Host = ?`, secondaryPasswordExpression(currentVersion))
+	tflog.Info(ctx, query, map[string]any{"args": args})
+	var hasSecondaryPassword bool
+	if err := db.QueryRowContext(ctx, query, args...).Scan(&hasSecondaryPassword); err != nil {
+		return false, err
+	}
+	return hasSecondaryPassword, nil
 }
 
 // stateWithoutDiscardOldPassword returns a copy of `data` with `discard_old_password` unset.

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -364,7 +364,8 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	tflog.Info(ctx, sql, map[string]any{"args": args})
 	rows, err := db.QueryContext(ctx, sql, args...)
 	if err != nil {
-		resp.Diagnostics.AddError("Failed creating user", err.Error())
+		resp.Diagnostics.AddError("Failed updating user", err.Error())
+		return
 	}
 	defer func() { _ = rows.Close() }()
 	for rows.Next() {

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -62,12 +62,7 @@ func secondaryPasswordExpression(currentVersion *version.Version) string {
 }
 
 // checkDualPasswordSupport reports a clear error instead of letting MySQL fail with a syntax error.
-// `serverVersion` is also called on connecting to MySQL, so it does not add a new failure mode.
-func checkDualPasswordSupport(db *sql.DB) error {
-	currentVersion, err := serverVersion(db)
-	if err != nil {
-		return err
-	}
+func checkDualPasswordSupport(currentVersion *version.Version) error {
 	if !supportsDualPassword(currentVersion) {
 		return fmt.Errorf("dual password requires MySQL %s or later, but the server version is %s", dualPasswordMinVersion, currentVersion)
 	}
@@ -466,12 +461,6 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 					"Applying both would retain the current password and discard it right away.")
 			return
 		}
-		if authOption.RetainCurrentPassword.ValueBool() || discardOldPassword {
-			if err := checkDualPasswordSupport(db); err != nil {
-				resp.Diagnostics.AddError("Could not use dual password", err.Error())
-				return
-			}
-		}
 		// `RETAIN CURRENT PASSWORD` is available only when the statement changes the password.
 		passwordChanged := false
 		if authOption.Plugin.IsNull() {
@@ -501,14 +490,22 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 				}
 			}
 		}
-		if authOption.RetainCurrentPassword.ValueBool() {
-			if passwordChanged {
-				sql += ` RETAIN CURRENT PASSWORD`
-			} else {
-				resp.Diagnostics.AddWarning(
-					"Ignored retain_current_password",
-					"`retain_current_password` requires changing the password. Set `auth_string` or `random_password` to retain the current password.")
+		retainCurrentPassword := authOption.RetainCurrentPassword.ValueBool() && passwordChanged
+		if authOption.RetainCurrentPassword.ValueBool() && !passwordChanged {
+			resp.Diagnostics.AddWarning(
+				"Ignored retain_current_password",
+				"`retain_current_password` requires changing the password. Set `auth_string` or `random_password` to retain the current password.")
+		}
+		// The server version is checked where a dual password statement is actually issued, so
+		// that an ignored `retain_current_password` does not fail on a server which never sees it.
+		if retainCurrentPassword || discardOldPassword {
+			if err := checkDualPasswordSupport(currentVersion); err != nil {
+				resp.Diagnostics.AddError("Could not use dual password", err.Error())
+				return
 			}
+		}
+		if retainCurrentPassword {
+			sql += ` RETAIN CURRENT PASSWORD`
 		}
 	}
 	if data.Lock.ValueBool() {

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -41,6 +41,14 @@ const (
 // See https://dev.mysql.com/doc/refman/8.0/en/password-management.html#dual-passwords for more details.
 var dualPasswordMinVersion = version.Must(version.NewVersion("8.0.14"))
 
+// supportsDualPassword reports whether the server version supports dual password.
+// `@@GLOBAL.version` often carries a suffix such as `-log` with binary logging enabled,
+// `-commercial`, or a distribution specific one. `go-version` treats the suffix as a
+// prerelease, which sorts below the release itself, so compare only the core version.
+func supportsDualPassword(currentVersion *version.Version) bool {
+	return !currentVersion.Core().LessThan(dualPasswordMinVersion)
+}
+
 // checkDualPasswordSupport reports a clear error instead of letting MySQL fail with a syntax error.
 // `serverVersion` is also called on connecting to MySQL, so it does not add a new failure mode.
 func checkDualPasswordSupport(db *sql.DB) error {
@@ -48,7 +56,7 @@ func checkDualPasswordSupport(db *sql.DB) error {
 	if err != nil {
 		return err
 	}
-	if currentVersion.LessThan(dualPasswordMinVersion) {
+	if !supportsDualPassword(currentVersion) {
 		return fmt.Errorf("dual password requires MySQL %s or later, but the server version is %s", dualPasswordMinVersion, currentVersion)
 	}
 	return nil

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/go-version"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -486,12 +487,45 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	if discardOldPassword {
 		_ = rows.Close()
 		if err := alterUserDiscardOldPassword(ctx, db, data); err != nil {
+			// MySQL DDL is not transactional, so the `ALTER USER` above is already committed.
+			// Save the state to keep it in sync with the server before reporting the error.
+			partialState, diags := stateWithoutDiscardOldPassword(data)
+			resp.Diagnostics.Append(diags...)
+			resp.Diagnostics.Append(resp.State.Set(ctx, partialState)...)
 			resp.Diagnostics.AddError("Failed discarding old password", err.Error())
 			return
 		}
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// stateWithoutDiscardOldPassword returns a copy of `data` with `discard_old_password` unset.
+// It is used when `DISCARD OLD PASSWORD` fails after the preceding `ALTER USER` succeeded.
+// Keeping the attribute unset leaves a diff against the configuration, so that the next
+// apply retries the discard instead of reporting no changes while the secondary password
+// is still alive on the server.
+func stateWithoutDiscardOldPassword(data *UserResourceModel) (*UserResourceModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if data.AuthOption.IsNull() || data.AuthOption.IsUnknown() {
+		return data, diags
+	}
+
+	attributes := make(map[string]attr.Value, len(AuthOptionModelTypes))
+	for name, value := range data.AuthOption.Attributes() {
+		attributes[name] = value
+	}
+	attributes["discard_old_password"] = types.BoolNull()
+
+	authOption, d := types.ObjectValue(AuthOptionModelTypes, attributes)
+	diags.Append(d...)
+	if diags.HasError() {
+		return data, diags
+	}
+
+	partialState := *data
+	partialState.AuthOption = authOption
+	return &partialState, diags
 }
 
 func alterUserDiscardOldPassword(ctx context.Context, db *sql.DB, data *UserResourceModel) error {

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -2,10 +2,12 @@ package provider
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"strings"
 
 	"github.com/go-sql-driver/mysql"
+	"github.com/hashicorp/go-version"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -24,14 +26,33 @@ import (
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var (
-	_ resource.Resource                = &UserResource{}
-	_ resource.ResourceWithConfigure   = &UserResource{}
-	_ resource.ResourceWithImportState = &UserResource{}
+	_ resource.Resource                   = &UserResource{}
+	_ resource.ResourceWithConfigure      = &UserResource{}
+	_ resource.ResourceWithImportState    = &UserResource{}
+	_ resource.ResourceWithValidateConfig = &UserResource{}
 )
 
 const (
 	awsAuthenticationPlugin = "AWSAuthenticationPlugin"
 )
+
+// dualPasswordMinVersion is the minimum MySQL version that supports dual password.
+// The dual password support was added in MySQL 8.0.14, while this provider supports MySQL 8.0 or later.
+// See https://dev.mysql.com/doc/refman/8.0/en/password-management.html#dual-passwords for more details.
+var dualPasswordMinVersion = version.Must(version.NewVersion("8.0.14"))
+
+// checkDualPasswordSupport reports a clear error instead of letting MySQL fail with a syntax error.
+// `serverVersion` is also called on connecting to MySQL, so it does not add a new failure mode.
+func checkDualPasswordSupport(db *sql.DB) error {
+	currentVersion, err := serverVersion(db)
+	if err != nil {
+		return err
+	}
+	if currentVersion.LessThan(dualPasswordMinVersion) {
+		return fmt.Errorf("dual password requires MySQL %s or later, but the server version is %s", dualPasswordMinVersion, currentVersion)
+	}
+	return nil
+}
 
 func NewUserResource() resource.Resource {
 	return &UserResource{}
@@ -52,15 +73,19 @@ type UserResourceModel struct {
 }
 
 type AuthOptionModel struct {
-	Plugin         types.String `tfsdk:"plugin"`
-	AuthString     types.String `tfsdk:"auth_string"`
-	RandomPassword types.Bool   `tfsdk:"random_password"`
+	Plugin                types.String `tfsdk:"plugin"`
+	AuthString            types.String `tfsdk:"auth_string"`
+	RandomPassword        types.Bool   `tfsdk:"random_password"`
+	RetainCurrentPassword types.Bool   `tfsdk:"retain_current_password"`
+	DiscardOldPassword    types.Bool   `tfsdk:"discard_old_password"`
 }
 
 var AuthOptionModelTypes = map[string]attr.Type{
-	"plugin":          types.StringType,
-	"auth_string":     types.StringType,
-	"random_password": types.BoolType,
+	"plugin":                  types.StringType,
+	"auth_string":             types.StringType,
+	"random_password":         types.BoolType,
+	"retain_current_password": types.BoolType,
+	"discard_old_password":    types.BoolType,
 }
 
 func (r *UserResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -105,6 +130,20 @@ func (r *UserResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 						MarkdownDescription: "Generate random password when create user. Display generated password after creating user. Conflicts with `auth_string`.",
 						Optional:            true,
 					},
+					"retain_current_password": schema.BoolAttribute{
+						MarkdownDescription: "Keep the current password as the secondary password when changing the password. Requires MySQL 8.0.14 or later. " +
+							"See MySQL Reference Manual [8.2.15 Password Management](https://dev.mysql.com/doc/refman/8.0/en/password-management.html#dual-passwords) for more details. " +
+							"This option is ignored when creating a user because `CREATE USER` does not accept `RETAIN CURRENT PASSWORD`. " +
+							"Cannot be true at the same time as `discard_old_password`.",
+						Optional: true,
+					},
+					"discard_old_password": schema.BoolAttribute{
+						MarkdownDescription: "Discard the secondary password. Requires MySQL 8.0.14 or later. " +
+							"See MySQL Reference Manual [8.2.15 Password Management](https://dev.mysql.com/doc/refman/8.0/en/password-management.html#dual-passwords) for more details. " +
+							"This option is ignored when creating a user because a new user has no secondary password. " +
+							"Cannot be true at the same time as `retain_current_password`.",
+						Optional: true,
+					},
 				},
 			},
 		},
@@ -117,6 +156,30 @@ func (r *UserResource) ConfigValidators(ctx context.Context) []resource.ConfigVa
 			path.MatchRoot("auth_option").AtName("auth_string"),
 			path.MatchRoot("auth_option").AtName("random_password"),
 		),
+	}
+}
+
+// ValidateConfig rejects only the combination of `retain_current_password` and `discard_old_password` being true.
+// `resourcevalidator.Conflicting` cannot be used here because it rejects an explicit `false`,
+// which is common when the value comes from an expression.
+func (r *UserResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var data *UserResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() || data.AuthOption.IsNull() || data.AuthOption.IsUnknown() {
+		return
+	}
+
+	var authOption AuthOptionModel
+	resp.Diagnostics.Append(data.AuthOption.As(ctx, &authOption, basetypes.ObjectAsOptions{})...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if authOption.RetainCurrentPassword.ValueBool() && authOption.DiscardOldPassword.ValueBool() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("auth_option").AtName("discard_old_password"),
+			"Invalid Attribute Combination",
+			"`retain_current_password` and `discard_old_password` cannot be true at the same time.")
 	}
 }
 
@@ -154,6 +217,11 @@ func (r *UserResource) Create(ctx context.Context, req resource.CreateRequest, r
 	if !data.AuthOption.IsNull() {
 		var authOption *AuthOptionModel
 		resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("auth_option"), &authOption)...)
+		if authOption.RetainCurrentPassword.ValueBool() || authOption.DiscardOldPassword.ValueBool() {
+			resp.Diagnostics.AddWarning(
+				"Ignored dual password options on creating user",
+				"`retain_current_password` and `discard_old_password` are available only in `ALTER USER`.")
+		}
 		if authOption.Plugin.IsNull() {
 			if authOption.RandomPassword.ValueBool() {
 				sql += ` IDENTIFIED BY RANDOM PASSWORD`
@@ -277,9 +345,11 @@ WHERE
 			}
 			if plugin != defaultAuthenticationPlugin {
 				attributes := map[string]attr.Value{
-					"plugin":          types.StringValue(plugin),
-					"auth_string":     types.StringNull(),
-					"random_password": types.BoolNull(),
+					"plugin":                  types.StringValue(plugin),
+					"auth_string":             types.StringNull(),
+					"random_password":         types.BoolNull(),
+					"retain_current_password": types.BoolNull(),
+					"discard_old_password":    types.BoolNull(),
 				}
 				data.AuthOption = types.ObjectValueMust(AuthOptionModelTypes, attributes)
 			}
@@ -297,6 +367,9 @@ WHERE
 				attributes["auth_string"] = authOption.AuthString
 			}
 			attributes["random_password"] = authOption.RandomPassword
+			// The dual password options are write-only options for `ALTER USER`, so keep the configured values.
+			attributes["retain_current_password"] = authOption.RetainCurrentPassword
+			attributes["discard_old_password"] = authOption.DiscardOldPassword
 
 			data.AuthOption = types.ObjectValueMust(AuthOptionModelTypes, attributes)
 		}
@@ -328,16 +401,28 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		args = append(args, data.Host.ValueString())
 	}
 
+	discardOldPassword := false
 	if !data.AuthOption.IsNull() {
 		var authOption *AuthOptionModel
 		resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("auth_option"), &authOption)...)
+		discardOldPassword = authOption.DiscardOldPassword.ValueBool()
+		if authOption.RetainCurrentPassword.ValueBool() || discardOldPassword {
+			if err := checkDualPasswordSupport(db); err != nil {
+				resp.Diagnostics.AddError("Could not use dual password", err.Error())
+				return
+			}
+		}
+		// `RETAIN CURRENT PASSWORD` is available only when the statement changes the password.
+		passwordChanged := false
 		if authOption.Plugin.IsNull() {
 			if authOption.RandomPassword.ValueBool() {
 				sql += ` IDENTIFIED BY RANDOM PASSWORD`
+				passwordChanged = true
 			} else if !authOption.AuthString.IsNull() {
 				sql += ` IDENTIFIED BY ?`
 				args = append(args, authOption.AuthString.ValueString())
-			} else {
+				passwordChanged = true
+			} else if !discardOldPassword {
 				resp.Diagnostics.AddWarning("Could not add IDENTIFIED clause without plugin", "")
 			}
 		} else {
@@ -348,10 +433,21 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 				sql += fmt.Sprintf(` IDENTIFIED WITH %s`, plugin)
 				if authOption.RandomPassword.ValueBool() {
 					sql += ` BY RANDOM PASSWORD`
+					passwordChanged = true
 				} else if !authOption.AuthString.IsNull() {
 					sql += ` BY ?`
 					args = append(args, authOption.AuthString.ValueString())
+					passwordChanged = true
 				}
+			}
+		}
+		if authOption.RetainCurrentPassword.ValueBool() {
+			if passwordChanged {
+				sql += ` RETAIN CURRENT PASSWORD`
+			} else {
+				resp.Diagnostics.AddWarning(
+					"Ignored retain_current_password",
+					"`retain_current_password` requires changing the password. Set `auth_string` or `random_password` to retain the current password.")
 			}
 		}
 	}
@@ -378,8 +474,32 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 			fmt.Sprintf("Generated password: %s", generatedPassword),
 			"The generated password is not saved in tfstate")
 	}
+	// `DISCARD OLD PASSWORD` cannot be combined with `IDENTIFIED BY` in a single statement.
+	if discardOldPassword {
+		_ = rows.Close()
+		if err := alterUserDiscardOldPassword(ctx, db, data); err != nil {
+			resp.Diagnostics.AddError("Failed discarding old password", err.Error())
+			return
+		}
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func alterUserDiscardOldPassword(ctx context.Context, db *sql.DB, data *UserResourceModel) error {
+	var args []interface{}
+	args = append(args, data.Name.ValueString())
+
+	query := `ALTER USER ?`
+	if !data.Host.IsNull() {
+		query += `@?`
+		args = append(args, data.Host.ValueString())
+	}
+	query += ` DISCARD OLD PASSWORD`
+
+	tflog.Info(ctx, query, map[string]any{"args": args})
+	_, err := db.ExecContext(ctx, query, args...)
+	return err
 }
 
 func (r *UserResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -456,6 +456,16 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		var authOption *AuthOptionModel
 		resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("auth_option"), &authOption)...)
 		discardOldPassword = authOption.DiscardOldPassword.ValueBool()
+		// `ValidateConfig` sees an unknown value as false, so repeat the check on the resolved
+		// values. Without it the statement would retain the current password and the following
+		// `DISCARD OLD PASSWORD` would immediately discard it, with no error and no warning.
+		if authOption.RetainCurrentPassword.ValueBool() && discardOldPassword {
+			resp.Diagnostics.AddError(
+				"Conflicting dual password options",
+				"`retain_current_password` and `discard_old_password` cannot be true at the same time. "+
+					"Applying both would retain the current password and discard it right away.")
+			return
+		}
 		if authOption.RetainCurrentPassword.ValueBool() || discardOldPassword {
 			if err := checkDualPasswordSupport(db); err != nil {
 				resp.Diagnostics.AddError("Could not use dual password", err.Error())

--- a/internal/provider/user_resource_test.go
+++ b/internal/provider/user_resource_test.go
@@ -8,6 +8,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/okkez/terraform-provider-mysql/internal/utils"
@@ -44,6 +47,56 @@ func TestSupportsDualPassword(t *testing.T) {
 				t.Errorf("supportsDualPassword(%q): got %t, want %t", tt.versionString, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestStateWithoutDiscardOldPassword checks that `discard_old_password` is unset while the
+// other attributes are kept, so that a failed discard still leaves a diff to retry.
+func TestStateWithoutDiscardOldPassword(t *testing.T) {
+	t.Parallel()
+	authOption := types.ObjectValueMust(AuthOptionModelTypes, map[string]attr.Value{
+		"plugin":                  types.StringNull(),
+		"auth_string":             types.StringValue("password"),
+		"random_password":         types.BoolNull(),
+		"retain_current_password": types.BoolValue(false),
+		"discard_old_password":    types.BoolValue(true),
+	})
+	data := &UserResourceModel{
+		Name:       types.StringValue("test-user"),
+		Host:       types.StringValue("%"),
+		Lock:       types.BoolValue(true),
+		AuthOption: authOption,
+	}
+
+	got, diags := stateWithoutDiscardOldPassword(data)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	var gotAuthOption AuthOptionModel
+	if diags := got.AuthOption.As(context.Background(), &gotAuthOption, basetypes.ObjectAsOptions{}); diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if !gotAuthOption.DiscardOldPassword.IsNull() {
+		t.Errorf("discard_old_password: got %v, want null", gotAuthOption.DiscardOldPassword)
+	}
+	if gotAuthOption.AuthString.ValueString() != "password" {
+		t.Errorf("auth_string: got %q, want %q", gotAuthOption.AuthString.ValueString(), "password")
+	}
+	if gotAuthOption.RetainCurrentPassword.ValueBool() {
+		t.Errorf("retain_current_password: got true, want false")
+	}
+	if !got.Lock.ValueBool() {
+		t.Errorf("lock: got false, want true")
+	}
+
+	// The argument must not be modified, because it is still used to report the error.
+	var originalAuthOption AuthOptionModel
+	if diags := data.AuthOption.As(context.Background(), &originalAuthOption, basetypes.ObjectAsOptions{}); diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if !originalAuthOption.DiscardOldPassword.ValueBool() {
+		t.Errorf("the argument was modified: discard_old_password got %v, want true", originalAuthOption.DiscardOldPassword)
 	}
 }
 

--- a/internal/provider/user_resource_test.go
+++ b/internal/provider/user_resource_test.go
@@ -465,7 +465,7 @@ func TestAccUserResource_DualPasswordUnsupportedVersion(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			if err := checkDualPasswordSupport(testDatabase()); err == nil {
+			if err := checkDualPasswordSupport(testServerVersion(t)); err == nil {
 				t.Skipf("The server supports dual password")
 			}
 		},
@@ -798,6 +798,17 @@ func testAccUserResource_CheckLoginFailure(user UserModel, password string) reso
 		}
 		return nil
 	}
+}
+
+// testServerVersion returns the version of the server under test.
+// A failure here is a broken test environment, not an unsupported server, so it fails the test
+// instead of being reported as a missing dual password support.
+func testServerVersion(t *testing.T) *version.Version {
+	currentVersion, err := serverVersion(testDatabase())
+	if err != nil {
+		t.Fatalf("failed getting the server version: %v", err)
+	}
+	return currentVersion
 }
 
 // testLogin opens a new connection without using the connection cache,

--- a/internal/provider/user_resource_test.go
+++ b/internal/provider/user_resource_test.go
@@ -483,6 +483,33 @@ func TestAccUserResource_DualPasswordUnsupportedVersion(t *testing.T) {
 	})
 }
 
+// TestAccUserResource_DualPasswordBothTrueFromExpression checks that the both options cannot be
+// true at the same time when one of them is derived from an expression rather than a literal.
+// It does not tell the two layers apart: `ValidateConfig` rejects the combination as soon as the
+// value is resolved, and `Update` is only reached for a value which is still unknown by then, so
+// either message is accepted. The check in `Update` was verified by disabling the one in
+// `ValidateConfig`, which makes this apply succeed with no error and no warning.
+func TestAccUserResource_DualPasswordBothTrueFromExpression(t *testing.T) {
+	user := NewRandomUser("test-user", "%")
+	helper := NewRandomUser("test-user", "%")
+	t.Logf("%+v %+v\n", user, helper)
+	users := []UserModel{user, helper}
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccUserResource_CheckDestroy(users),
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserResource_ConfigWithDualPassword(t, user.GetName(), user.GetHost(), "password1", false, false),
+			},
+			{
+				Config:      testAccUserResource_ConfigWithRetainCurrentPasswordFromExpression(t, user.GetName(), helper.GetName(), user.GetHost(), "password2"),
+				ExpectError: regexp.MustCompile("Invalid Attribute Combination|Conflicting dual password options"),
+			},
+		},
+	})
+}
+
 // TestAccUserResource_DualPasswordBothTrue checks that the both options cannot be true at the same time.
 func TestAccUserResource_DualPasswordBothTrue(t *testing.T) {
 	user := NewRandomUser("test-user", "%")
@@ -644,6 +671,45 @@ resource "mysql_user" "test" {
 		AuthString:            authString,
 		RetainCurrentPassword: retainCurrentPassword,
 		DiscardOldPassword:    discardOldPassword,
+	}
+	config, err := utils.Render(source, data)
+	if err != nil {
+		t.Fatal(err)
+		t.Fail()
+	}
+	return config
+}
+
+// testAccUserResource_ConfigWithRetainCurrentPasswordFromExpression derives `retain_current_password`
+// from a resource which is created by the same apply, so that the value is unknown while the
+// configuration is validated and only known when the user is updated.
+func testAccUserResource_ConfigWithRetainCurrentPasswordFromExpression(t *testing.T, name, helperName, host, authString string) string {
+	source := `
+resource "mysql_user" "helper" {
+  name = "{{ .HelperName }}"
+  host = "{{ .Host }}"
+}
+
+resource "mysql_user" "test" {
+  name = "{{ .Name }}"
+  host = "{{ .Host }}"
+  auth_option {
+    auth_string             = "{{ .AuthString }}"
+    retain_current_password = mysql_user.helper.id != ""
+    discard_old_password    = true
+  }
+}
+`
+	data := struct {
+		Name       string
+		HelperName string
+		Host       string
+		AuthString string
+	}{
+		Name:       name,
+		HelperName: helperName,
+		Host:       host,
+		AuthString: authString,
 	}
 	config, err := utils.Render(source, data)
 	if err != nil {

--- a/internal/provider/user_resource_test.go
+++ b/internal/provider/user_resource_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/go-version"
@@ -45,6 +46,37 @@ func TestSupportsDualPassword(t *testing.T) {
 			}
 			if got := supportsDualPassword(currentVersion); got != tt.want {
 				t.Errorf("supportsDualPassword(%q): got %t, want %t", tt.versionString, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSecondaryPasswordExpression checks that `User_attributes` is not referenced on a server
+// which does not have the column, because referencing it fails with ER_BAD_FIELD_ERROR.
+func TestSecondaryPasswordExpression(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		versionString        string
+		wantColumnReferenced bool
+	}{
+		{"8.0.13", false},
+		{"8.0.13-log", false},
+		{"8.0.14", true},
+		{"8.0.14-log", true},
+		{"8.0.39", true},
+		{"8.4.0", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.versionString, func(t *testing.T) {
+			t.Parallel()
+			currentVersion, err := version.NewVersion(tt.versionString)
+			if err != nil {
+				t.Fatalf("failed parsing version %q: %v", tt.versionString, err)
+			}
+			got := secondaryPasswordExpression(currentVersion)
+			if strings.Contains(got, "User_attributes") != tt.wantColumnReferenced {
+				t.Errorf("secondaryPasswordExpression(%q) = %q, want User_attributes referenced: %t",
+					tt.versionString, got, tt.wantColumnReferenced)
 			}
 		})
 	}
@@ -266,6 +298,7 @@ func TestAccUserResource_DualPassword(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("mysql_user.test", "id", user.GetID()),
 					resource.TestCheckResourceAttr("mysql_user.test", "auth_option.auth_string", "password1"),
+					resource.TestCheckResourceAttr("mysql_user.test", "has_secondary_password", "false"),
 					testAccUserResource_CheckSecondaryPassword(user, false),
 					testAccUserResource_CheckLogin(user, "password1"),
 					testAccUserResource_CheckLoginFailure(user, "password2"),
@@ -277,6 +310,7 @@ func TestAccUserResource_DualPassword(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("mysql_user.test", "auth_option.auth_string", "password2"),
 					resource.TestCheckResourceAttr("mysql_user.test", "auth_option.retain_current_password", "true"),
+					resource.TestCheckResourceAttr("mysql_user.test", "has_secondary_password", "true"),
 					testAccUserResource_CheckSecondaryPassword(user, true),
 					testAccUserResource_CheckLogin(user, "password1"),
 					testAccUserResource_CheckLogin(user, "password2"),
@@ -288,6 +322,7 @@ func TestAccUserResource_DualPassword(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("mysql_user.test", "auth_option.auth_string", "password2"),
 					resource.TestCheckResourceAttr("mysql_user.test", "auth_option.discard_old_password", "true"),
+					resource.TestCheckResourceAttr("mysql_user.test", "has_secondary_password", "false"),
 					testAccUserResource_CheckSecondaryPassword(user, false),
 					testAccUserResource_CheckLogin(user, "password2"),
 					testAccUserResource_CheckLoginFailure(user, "password1"),
@@ -335,6 +370,51 @@ func TestAccUserResource_DualPasswordRotateTwice(t *testing.T) {
 	})
 }
 
+// TestAccUserResource_DualPasswordAbandonedRotation checks that `has_secondary_password` reports
+// a rotation which was never finished with `discard_old_password`. Removing
+// `retain_current_password` does not discard the secondary password, so the retained password
+// stays valid and only this attribute makes it visible.
+func TestAccUserResource_DualPasswordAbandonedRotation(t *testing.T) {
+	user := NewRandomUser("test-user", "%")
+	t.Logf("%+v\n", user)
+	users := []UserModel{user}
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccUserResource_CheckDestroy(users),
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserResource_ConfigWithDualPassword(t, user.GetName(), user.GetHost(), "password1", false, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("mysql_user.test", "has_secondary_password", "false"),
+				),
+			},
+			// Retain the current password, which keeps `password1` as the secondary password
+			{
+				Config: testAccUserResource_ConfigWithDualPassword(t, user.GetName(), user.GetHost(), "password2", true, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("mysql_user.test", "has_secondary_password", "true"),
+					testAccUserResource_CheckLogin(user, "password1"),
+					testAccUserResource_CheckLogin(user, "password2"),
+				),
+			},
+			// Abandon the rotation by dropping `retain_current_password` instead of discarding.
+			// `password1` is still the secondary password, so it keeps working.
+			{
+				Config: testAccUserResource_ConfigWithDualPassword(t, user.GetName(), user.GetHost(), "password3", false, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("mysql_user.test", "has_secondary_password", "true"),
+					testAccUserResource_CheckSecondaryPassword(user, true),
+					testAccUserResource_CheckLogin(user, "password1"),
+					testAccUserResource_CheckLoginFailure(user, "password2"),
+					testAccUserResource_CheckLogin(user, "password3"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
 // TestAccUserResource_DualPasswordWithPlugin checks the dual password options
 // with `IDENTIFIED WITH <plugin> BY ?`.
 func TestAccUserResource_DualPasswordWithPlugin(t *testing.T) {
@@ -356,6 +436,7 @@ func TestAccUserResource_DualPasswordWithPlugin(t *testing.T) {
 			{
 				Config: testAccUserResource_ConfigWithDualPasswordAndPlugin(t, user.GetName(), user.GetHost(), "caching_sha2_password", "password2", true, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("mysql_user.test", "has_secondary_password", "true"),
 					testAccUserResource_CheckSecondaryPassword(user, true),
 					testAccUserResource_CheckLogin(user, "password1"),
 					testAccUserResource_CheckLogin(user, "password2"),
@@ -364,6 +445,7 @@ func TestAccUserResource_DualPasswordWithPlugin(t *testing.T) {
 			{
 				Config: testAccUserResource_ConfigWithDualPasswordAndPlugin(t, user.GetName(), user.GetHost(), "caching_sha2_password", "password2", false, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("mysql_user.test", "has_secondary_password", "false"),
 					testAccUserResource_CheckSecondaryPassword(user, false),
 					testAccUserResource_CheckLoginFailure(user, "password1"),
 					testAccUserResource_CheckLogin(user, "password2"),

--- a/internal/provider/user_resource_test.go
+++ b/internal/provider/user_resource_test.go
@@ -1,6 +1,8 @@
 package provider
 
 import (
+	"context"
+	"database/sql"
 	"fmt"
 	"regexp"
 	"testing"
@@ -161,6 +163,172 @@ func TestAccUserResource_Lock(t *testing.T) {
 	})
 }
 
+func TestAccUserResource_DualPassword(t *testing.T) {
+	user := NewRandomUser("test-user", "%")
+	t.Logf("%+v\n", user)
+	users := []UserModel{user}
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccUserResource_CheckDestroy(users),
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccUserResource_ConfigWithDualPassword(t, user.GetName(), user.GetHost(), "password1", false, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("mysql_user.test", "id", user.GetID()),
+					resource.TestCheckResourceAttr("mysql_user.test", "auth_option.auth_string", "password1"),
+					testAccUserResource_CheckSecondaryPassword(user, false),
+					testAccUserResource_CheckLogin(user, "password1"),
+					testAccUserResource_CheckLoginFailure(user, "password2"),
+				),
+			},
+			// Change the primary password and retain the current password as the secondary password
+			{
+				Config: testAccUserResource_ConfigWithDualPassword(t, user.GetName(), user.GetHost(), "password2", true, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("mysql_user.test", "auth_option.auth_string", "password2"),
+					resource.TestCheckResourceAttr("mysql_user.test", "auth_option.retain_current_password", "true"),
+					testAccUserResource_CheckSecondaryPassword(user, true),
+					testAccUserResource_CheckLogin(user, "password1"),
+					testAccUserResource_CheckLogin(user, "password2"),
+				),
+			},
+			// Discard the secondary password
+			{
+				Config: testAccUserResource_ConfigWithDualPassword(t, user.GetName(), user.GetHost(), "password2", false, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("mysql_user.test", "auth_option.auth_string", "password2"),
+					resource.TestCheckResourceAttr("mysql_user.test", "auth_option.discard_old_password", "true"),
+					testAccUserResource_CheckSecondaryPassword(user, false),
+					testAccUserResource_CheckLogin(user, "password2"),
+					testAccUserResource_CheckLoginFailure(user, "password1"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+// TestAccUserResource_DualPasswordRotateTwice checks that MySQL keeps only one secondary password,
+// so the second rotation invalidates the password retained by the first rotation.
+func TestAccUserResource_DualPasswordRotateTwice(t *testing.T) {
+	user := NewRandomUser("test-user", "%")
+	t.Logf("%+v\n", user)
+	users := []UserModel{user}
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccUserResource_CheckDestroy(users),
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserResource_ConfigWithDualPassword(t, user.GetName(), user.GetHost(), "password1", false, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccUserResource_CheckLogin(user, "password1"),
+				),
+			},
+			{
+				Config: testAccUserResource_ConfigWithDualPassword(t, user.GetName(), user.GetHost(), "password2", true, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccUserResource_CheckLogin(user, "password1"),
+					testAccUserResource_CheckLogin(user, "password2"),
+				),
+			},
+			{
+				Config: testAccUserResource_ConfigWithDualPassword(t, user.GetName(), user.GetHost(), "password3", true, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccUserResource_CheckLoginFailure(user, "password1"),
+					testAccUserResource_CheckLogin(user, "password2"),
+					testAccUserResource_CheckLogin(user, "password3"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+// TestAccUserResource_DualPasswordWithPlugin checks the dual password options
+// with `IDENTIFIED WITH <plugin> BY ?`.
+func TestAccUserResource_DualPasswordWithPlugin(t *testing.T) {
+	user := NewRandomUser("test-user", "%")
+	t.Logf("%+v\n", user)
+	users := []UserModel{user}
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccUserResource_CheckDestroy(users),
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserResource_ConfigWithDualPasswordAndPlugin(t, user.GetName(), user.GetHost(), "caching_sha2_password", "password1", false, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("mysql_user.test", "auth_option.plugin", "caching_sha2_password"),
+					testAccUserResource_CheckLogin(user, "password1"),
+				),
+			},
+			{
+				Config: testAccUserResource_ConfigWithDualPasswordAndPlugin(t, user.GetName(), user.GetHost(), "caching_sha2_password", "password2", true, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccUserResource_CheckSecondaryPassword(user, true),
+					testAccUserResource_CheckLogin(user, "password1"),
+					testAccUserResource_CheckLogin(user, "password2"),
+				),
+			},
+			{
+				Config: testAccUserResource_ConfigWithDualPasswordAndPlugin(t, user.GetName(), user.GetHost(), "caching_sha2_password", "password2", false, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccUserResource_CheckSecondaryPassword(user, false),
+					testAccUserResource_CheckLoginFailure(user, "password1"),
+					testAccUserResource_CheckLogin(user, "password2"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+// TestAccUserResource_DualPasswordUnsupportedVersion checks that the provider reports a clear error
+// instead of letting MySQL fail with a syntax error. It runs only against MySQL earlier than 8.0.14.
+func TestAccUserResource_DualPasswordUnsupportedVersion(t *testing.T) {
+	user := NewRandomUser("test-user", "%")
+	t.Logf("%+v\n", user)
+	users := []UserModel{user}
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			if err := checkDualPasswordSupport(testDatabase()); err == nil {
+				t.Skipf("The server supports dual password")
+			}
+		},
+		CheckDestroy:             testAccUserResource_CheckDestroy(users),
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserResource_ConfigWithDualPassword(t, user.GetName(), user.GetHost(), "password1", false, false),
+			},
+			{
+				Config:      testAccUserResource_ConfigWithDualPassword(t, user.GetName(), user.GetHost(), "password2", true, false),
+				ExpectError: regexp.MustCompile("Could not use dual password"),
+			},
+		},
+	})
+}
+
+// TestAccUserResource_DualPasswordBothTrue checks that the both options cannot be true at the same time.
+func TestAccUserResource_DualPasswordBothTrue(t *testing.T) {
+	user := NewRandomUser("test-user", "%")
+	t.Logf("%+v\n", user)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccUserResource_ConfigWithDualPassword(t, user.GetName(), user.GetHost(), "password1", true, true),
+				ExpectError: regexp.MustCompile("Invalid Attribute Combination"),
+			},
+		},
+	})
+}
+
 func TestAccUserResource_ImportNonExistentRemoteObject(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -280,6 +448,134 @@ resource "mysql_user" "test" {
 		t.Fail()
 	}
 	return config
+}
+
+func testAccUserResource_ConfigWithDualPassword(t *testing.T, name, host, authString string, retainCurrentPassword, discardOldPassword bool) string {
+	source := `
+resource "mysql_user" "test" {
+  name = "{{ .Name }}"
+  host = "{{ .Host }}"
+  auth_option {
+    auth_string             = "{{ .AuthString }}"
+    retain_current_password = {{ .RetainCurrentPassword }}
+    discard_old_password    = {{ .DiscardOldPassword }}
+  }
+}
+`
+	data := struct {
+		Name                  string
+		Host                  string
+		AuthString            string
+		RetainCurrentPassword bool
+		DiscardOldPassword    bool
+	}{
+		Name:                  name,
+		Host:                  host,
+		AuthString:            authString,
+		RetainCurrentPassword: retainCurrentPassword,
+		DiscardOldPassword:    discardOldPassword,
+	}
+	config, err := utils.Render(source, data)
+	if err != nil {
+		t.Fatal(err)
+		t.Fail()
+	}
+	return config
+}
+
+func testAccUserResource_ConfigWithDualPasswordAndPlugin(t *testing.T, name, host, plugin, authString string, retainCurrentPassword, discardOldPassword bool) string {
+	source := `
+resource "mysql_user" "test" {
+  name = "{{ .Name }}"
+  host = "{{ .Host }}"
+  auth_option {
+    plugin                  = "{{ .Plugin }}"
+    auth_string             = "{{ .AuthString }}"
+    retain_current_password = {{ .RetainCurrentPassword }}
+    discard_old_password    = {{ .DiscardOldPassword }}
+  }
+}
+`
+	data := struct {
+		Name                  string
+		Host                  string
+		Plugin                string
+		AuthString            string
+		RetainCurrentPassword bool
+		DiscardOldPassword    bool
+	}{
+		Name:                  name,
+		Host:                  host,
+		Plugin:                plugin,
+		AuthString:            authString,
+		RetainCurrentPassword: retainCurrentPassword,
+		DiscardOldPassword:    discardOldPassword,
+	}
+	config, err := utils.Render(source, data)
+	if err != nil {
+		t.Fatal(err)
+		t.Fail()
+	}
+	return config
+}
+
+// testAccUserResource_CheckSecondaryPassword checks whether the user has a secondary password.
+// The secondary password is stored in the mysql.user.User_attributes column as `additional_password`.
+func testAccUserResource_CheckSecondaryPassword(user UserModel, expected bool) resource.TestCheckFunc {
+	return func(t *terraform.State) error {
+		db := testDatabase()
+		sql := `
+SELECT
+  JSON_CONTAINS_PATH(User_attributes, 'one', '$.additional_password') IS TRUE
+FROM
+  mysql.user
+WHERE
+  User = ?
+  AND Host = ?
+`
+		var actual bool
+		if err := db.QueryRow(sql, user.GetName(), user.GetHost()).Scan(&actual); err != nil {
+			return err
+		}
+		if actual != expected {
+			return fmt.Errorf("Unexpected secondary password state (%s): expected=%t, actual=%t", user.GetID(), expected, actual)
+		}
+		return nil
+	}
+}
+
+// testAccUserResource_CheckLogin checks that the user can log in with the given password.
+func testAccUserResource_CheckLogin(user UserModel, password string) resource.TestCheckFunc {
+	return func(t *terraform.State) error {
+		if err := testLogin(user, password); err != nil {
+			return fmt.Errorf("Could not log in as %s with the password %q: %v", user.GetID(), password, err)
+		}
+		return nil
+	}
+}
+
+// testAccUserResource_CheckLoginFailure checks that the user cannot log in with the given password.
+func testAccUserResource_CheckLoginFailure(user UserModel, password string) resource.TestCheckFunc {
+	return func(t *terraform.State) error {
+		if err := testLogin(user, password); err == nil {
+			return fmt.Errorf("Could log in as %s with the password %q unexpectedly", user.GetID(), password)
+		}
+		return nil
+	}
+}
+
+// testLogin opens a new connection without using the connection cache,
+// because the cached connection stays usable after the password is changed.
+func testLogin(user UserModel, password string) error {
+	conf := testMySQLConfig()
+	conf.Config.User = user.GetName()
+	conf.Config.Passwd = password
+	db, err := sql.Open("mysql", conf.Config.FormatDSN())
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	return db.PingContext(context.Background())
 }
 
 func testAccUserResource_CheckDestroy(users []UserModel) resource.TestCheckFunc {

--- a/internal/provider/user_resource_test.go
+++ b/internal/provider/user_resource_test.go
@@ -7,10 +7,45 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/okkez/terraform-provider-mysql/internal/utils"
 )
+
+// TestSupportsDualPassword checks the version comparison against the version strings
+// MySQL actually reports. `@@GLOBAL.version` often carries a suffix such as `-log`,
+// which `go-version` treats as a prerelease and sorts below the release itself.
+func TestSupportsDualPassword(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		versionString string
+		want          bool
+	}{
+		{"5.7.44", false},
+		{"8.0.13", false},
+		{"8.0.13-log", false},
+		{"8.0.14", true},
+		{"8.0.14-log", true},
+		{"8.0.14-commercial", true},
+		{"8.0.14-0ubuntu0.22.04.1", true},
+		{"8.0.39", true},
+		{"8.0.36-28", true},
+		{"8.4.0", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.versionString, func(t *testing.T) {
+			t.Parallel()
+			currentVersion, err := version.NewVersion(tt.versionString)
+			if err != nil {
+				t.Fatalf("failed parsing version %q: %v", tt.versionString, err)
+			}
+			if got := supportsDualPassword(currentVersion); got != tt.want {
+				t.Errorf("supportsDualPassword(%q): got %t, want %t", tt.versionString, got, tt.want)
+			}
+		})
+	}
+}
 
 func TestAccUserResource(t *testing.T) {
 	users := []UserModel{

--- a/internal/provider/user_resource_test.go
+++ b/internal/provider/user_resource_test.go
@@ -288,7 +288,7 @@ func TestAccUserResource_DualPassword(t *testing.T) {
 	t.Logf("%+v\n", user)
 	users := []UserModel{user}
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheckDualPassword(t) },
 		CheckDestroy:             testAccUserResource_CheckDestroy(users),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -340,7 +340,7 @@ func TestAccUserResource_DualPasswordRotateTwice(t *testing.T) {
 	t.Logf("%+v\n", user)
 	users := []UserModel{user}
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheckDualPassword(t) },
 		CheckDestroy:             testAccUserResource_CheckDestroy(users),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -379,7 +379,7 @@ func TestAccUserResource_DualPasswordAbandonedRotation(t *testing.T) {
 	t.Logf("%+v\n", user)
 	users := []UserModel{user}
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheckDualPassword(t) },
 		CheckDestroy:             testAccUserResource_CheckDestroy(users),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -422,7 +422,7 @@ func TestAccUserResource_DualPasswordWithPlugin(t *testing.T) {
 	t.Logf("%+v\n", user)
 	users := []UserModel{user}
 	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheckDualPassword(t) },
 		CheckDestroy:             testAccUserResource_CheckDestroy(users),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -463,12 +463,7 @@ func TestAccUserResource_DualPasswordUnsupportedVersion(t *testing.T) {
 	t.Logf("%+v\n", user)
 	users := []UserModel{user}
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-			if err := checkDualPasswordSupport(testServerVersion(t)); err == nil {
-				t.Skipf("The server supports dual password")
-			}
-		},
+		PreCheck:                 func() { testAccPreCheckDualPasswordUnsupported(t) },
 		CheckDestroy:             testAccUserResource_CheckDestroy(users),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -476,8 +471,11 @@ func TestAccUserResource_DualPasswordUnsupportedVersion(t *testing.T) {
 				Config: testAccUserResource_ConfigWithDualPassword(t, user.GetName(), user.GetHost(), "password1", false, false),
 			},
 			{
-				Config:      testAccUserResource_ConfigWithDualPassword(t, user.GetName(), user.GetHost(), "password2", true, false),
-				ExpectError: regexp.MustCompile("Could not use dual password"),
+				Config: testAccUserResource_ConfigWithDualPassword(t, user.GetName(), user.GetHost(), "password2", true, false),
+				// Asserting on the version specific message, because the summary
+				// `Could not use dual password` is reported for unrelated errors too.
+				ExpectError: regexp.MustCompile(fmt.Sprintf("requires MySQL %s or later",
+					regexp.QuoteMeta(dualPasswordMinVersion.String()))),
 			},
 		},
 	})
@@ -809,6 +807,25 @@ func testServerVersion(t *testing.T) *version.Version {
 		t.Fatalf("failed getting the server version: %v", err)
 	}
 	return currentVersion
+}
+
+// testAccPreCheckDualPassword skips the test unless the server supports dual password.
+// `mysql.user.User_attributes` does not exist before MySQL 8.0.14 either, so a test which
+// reads the secondary password state cannot run on an earlier server at all.
+func testAccPreCheckDualPassword(t *testing.T) {
+	testAccPreCheck(t)
+	if err := checkDualPasswordSupport(testServerVersion(t)); err != nil {
+		t.Skipf("%v", err)
+	}
+}
+
+// testAccPreCheckDualPasswordUnsupported skips the test unless the server is earlier than the
+// version which added dual password.
+func testAccPreCheckDualPasswordUnsupported(t *testing.T) {
+	testAccPreCheck(t)
+	if err := checkDualPasswordSupport(testServerVersion(t)); err == nil {
+		t.Skipf("The server supports dual password")
+	}
 }
 
 // testLogin opens a new connection without using the connection cache,

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+
+	"github.com/hashicorp/go-version"
 )
 
 func getDatabase(ctx context.Context, mysqlConf *MySQLConfiguration) (*sql.DB, error) {
@@ -16,17 +18,17 @@ func getDatabase(ctx context.Context, mysqlConf *MySQLConfiguration) (*sql.DB, e
 	return oneConnection.Db, nil
 }
 
-/*
-	func getDatabaseVersion(ctx context.Context, mysqlConf *MySQLConfiguration) *version.Version {
-		oneConnection, err := connectToMySQLInternal(ctx, mysqlConf)
+// getDatabaseVersion returns the server version determined when connecting.
+// The version is cached per DSN, so this does not query the server again.
+func getDatabaseVersion(ctx context.Context, mysqlConf *MySQLConfiguration) (*version.Version, error) {
+	oneConnection, err := connectToMySQLInternal(ctx, mysqlConf)
 
-		if err != nil {
-			tflog.Info(ctx, fmt.Sprintf("getting DB got us error: %v", err))
-		}
-
-		return oneConnection.Version
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to MySQL: %v", err)
 	}
-*/
+
+	return oneConnection.Version, nil
+}
 
 func quoteIdentifier(ctx context.Context, db *sql.DB, identifier string) (string, error) {
 	var quotedIdentifier string


### PR DESCRIPTION
## Summary

Add MySQL [dual password](https://dev.mysql.com/doc/refman/8.0/en/password-management.html#dual-passwords) support to `mysql_user`, so that a password can be rotated without downtime.

Two options are added to the `auth_option` block:

- `retain_current_password` - appends `RETAIN CURRENT PASSWORD` to `ALTER USER`, keeping the current password usable as the secondary password
- `discard_old_password` - issues `ALTER USER ... DISCARD OLD PASSWORD` to drop the secondary password

A read-only attribute is added to the resource:

- `has_secondary_password` - whether the account currently has a secondary password, read from `mysql.user.User_attributes`

A rotation takes two applies, with the deployment of the new password in between.

```hcl
# 1st apply: change the password, keeping the old one usable
resource "mysql_user" "app" {
  name = "app-user"
  auth_option {
    auth_string             = "new-password"
    retain_current_password = true
  }
}

# 2nd apply: after the applications use the new password
resource "mysql_user" "app" {
  name = "app-user"
  auth_option {
    auth_string          = "new-password"
    discard_old_password = true
  }
}
```

`discard_old_password` is the only way to invalidate the retained password. Removing `retain_current_password` from the configuration is not equivalent, because MySQL keeps the secondary password until `DISCARD OLD PASSWORD` is issued. `has_secondary_password` makes an unfinished rotation visible, and a `check` block turns it into a warning on every plan:

```hcl
check "no_stale_secondary_password" {
  assert {
    condition     = !mysql_user.app.has_secondary_password
    error_message = "app-user still has a secondary password. Run the discard step."
  }
}
```

## Behavior

- `DISCARD OLD PASSWORD` is executed as a separate statement, because MySQL rejects `ALTER USER ... IDENTIFIED BY ? DISCARD OLD PASSWORD` with a syntax error. `DISCARD OLD PASSWORD` is itself an `auth_option` in the grammar, so it cannot be combined with `IDENTIFIED BY`.
- `RETAIN CURRENT PASSWORD` is appended only when the statement changes the password (`auth_string` or `random_password` is set), since MySQL accepts it only in that form. Otherwise it is ignored with a warning.
- Both options are available only in `ALTER USER`, so they are ignored with a warning on `Create`.
- The two options are rejected only when both are `true`. The check lives in `ValidateConfig` rather than `resourcevalidator.Conflicting`, because `Conflicting` treats an explicit `false` as a conflict, which makes it impossible to scope a rotation to some users with an expression:

  ```hcl
  auth_option {
    auth_string             = random_password.main[each.key].result
    retain_current_password = contains(local.rotating_users, each.key)
  }
  ```

  `ValidateConfig` reads an unknown value as `false`, so the same check is repeated in `Update`, which has the resolved values.
- Dual password requires MySQL 8.0.14 or later, while this provider supports MySQL 8.0 or later. The server version is checked before the statement is issued so that users get a clear error instead of `You have an error in your SQL syntax ... near 'RETAIN CURRENT PASSWORD'`. Only the core version is compared, because `@@GLOBAL.version` often carries a suffix such as `-log`.
- `mysql.user.User_attributes` also exists only from 8.0.14, so `has_secondary_password` is read without referencing the column on an earlier server and is always `false` there.
- `retain_current_password` and `discard_old_password` are write-only options and are not read back from the server, so `Read` keeps the configured values. `has_secondary_password` is the attribute which reports the server side state.

MySQL behavior worth noting, confirmed against 8.0 while writing the tests:

- An account keeps only one secondary password, so a second rotation with `retain_current_password` invalidates the password retained by the first one.
- Changing the password without `RETAIN CURRENT PASSWORD` does *not* drop the secondary password. It survives until `DISCARD OLD PASSWORD` is issued.
- `DISCARD OLD PASSWORD` is a no-op when the account has no secondary password.

The first commit is a separate fix: `Update` dereferenced a nil `*sql.Rows` in the deferred `Close()` when `ALTER USER` failed, so the provider panicked instead of reporting the error. It is easy to hit with the new options, for example when MySQL returns `ER_SECOND_PASSWORD_CANNOT_BE_EMPTY` because the current password is empty.

## Changes after the review

Each review comment is addressed in its own commit.

| Comment | Commit |
| --- | --- |
| `serverVersion` suffix sorts below the release | `209d4e0` compare only `Core()` |
| state is not saved when the discard fails | `4e9158b` save it before reporting the error |
| the server side fact is never read back | `6336d34` add `has_secondary_password` |
| `ValidateConfig` reads an unknown value as false | `ee60d8f` repeat the check in `Update` |
| the version gate fires where no clause is issued | `b379758` gate where the statement is issued |
| the `PreCheck` accepts unrelated errors | `16e2ee5` assert the version specific message |

Two of them are not implemented exactly as suggested:

- **Saving the state on a failed discard** (`4e9158b`) keeps `discard_old_password` *unset* in the saved state. Saving the planned value would make the next plan report no changes, so the discard would never be retried while the secondary password is still alive on the server. Everything else comes from the plan, so the state matches the password which is already committed.
- **`has_secondary_password`** (`6336d34`) is `Computed` and therefore has no counterpart to diff against, so it does not appear in plan output by itself. `Objects have changed outside of Terraform` reports only the transition. The documented `check` block is what makes a standing unfinished rotation visible on every plan, so the example was added together with the attribute.

`has_secondary_password` is at the resource root rather than inside `auth_option`, because that block is optional and an absent block would leave the value nowhere to live.

## Test plan

Acceptance tests in `internal/provider/user_resource_test.go` verify the actual login results, not only the state:

- `TestAccUserResource_DualPassword` - rotates with `retain_current_password`, checks that both passwords can log in and that `has_secondary_password` and `mysql.user.User_attributes` agree, then that `discard_old_password` invalidates the old password
- `TestAccUserResource_DualPasswordRotateTwice` - only one secondary password is kept, so the second rotation invalidates the first retained password
- `TestAccUserResource_DualPasswordAbandonedRotation` - dropping `retain_current_password` instead of discarding keeps the retained password valid, and `has_secondary_password` stays `true`. This is the case the review asked to make visible
- `TestAccUserResource_DualPasswordWithPlugin` - `IDENTIFIED WITH caching_sha2_password BY ? RETAIN CURRENT PASSWORD`
- `TestAccUserResource_DualPasswordBothTrue` - the two options cannot both be literal `true`
- `TestAccUserResource_DualPasswordBothTrueFromExpression` - the same when the value comes from an expression rather than a literal
- `TestAccUserResource_DualPasswordUnsupportedVersion` - the version error, asserted on the version specific message. It skips unless the server is earlier than 8.0.14

Unit tests cover what needs no server:

- `TestSupportsDualPassword` - the version comparison against the strings MySQL reports, including `8.0.14-log`, `8.0.14-commercial` and `8.0.14-0ubuntu0.22.04.1`
- `TestSecondaryPasswordExpression` - `User_attributes` is not referenced below 8.0.14
- `TestStateWithoutDiscardOldPassword` - the state saved on a failed discard keeps every other attribute

The tests which need dual password now skip on an earlier server, so one invocation of the suite is green on any supported version.

Three changes have no automated test, and I would rather say so than imply coverage:

- **`b379758`** (the version gate) needs a server earlier than 8.0.14, which the CI matrix does not have. Verified locally by raising `dualPasswordMinVersion`: `retain_current_password` without a password change no longer fails, while a password change still does, and restoring the previous condition makes the first case fail again.
- **`ee60d8f`** (the check in `Update`) is behind `ValidateConfig`, which rejects the combination as soon as the value is resolved. `TestAccUserResource_DualPasswordBothTrueFromExpression` therefore passes without it. Verified by disabling the check in `ValidateConfig`, which makes that test apply successfully with no error and no warning.
- **`4e9158b`** (the state on a failed discard) would need the privileges of the test connection to be manipulated so that `DISCARD OLD PASSWORD` fails on its own.

Ran the whole suite locally against MySQL 8.0 and 8.4 from `docker-compose.yml`:

```
$ TF_ACC=1 MYSQL_ENDPOINT=localhost:33306 ... go test ./internal/provider/   # 8.0.46
ok  	github.com/okkez/terraform-provider-mysql/internal/provider	50.975s

$ TF_ACC=1 MYSQL_ENDPOINT=localhost:43306 ... go test ./internal/provider/   # 8.4.11
ok  	github.com/okkez/terraform-provider-mysql/internal/provider	50.086s
```

I also raised `dualPasswordMinVersion` to simulate a server without dual password support: the four tests which need it skip, `TestAccUserResource_DualPasswordUnsupportedVersion` runs, and the rest of the suite stays green. My earlier claim about running the suite against 8.0.13 was wrong, as you pointed out - `User_attributes` does not exist there, so those tests could only have failed rather than skipped. That is what the guards now fix.

`gofmt -l .`, `go vet ./...` and `go build ./...` are clean, and `go generate ./...` leaves no diff.

## Real-world usage

I used this branch to rotate the passwords of all the MySQL users in our environment on Aurora MySQL 3 (8.0.39), first on a development cluster and then in production. The passwords are generated by `random_password`, so the flow was:

1. `retain_current_password = true` with `terraform apply -replace='random_password.main["<user>"]'`
2. deploy the new password to the applications
3. `discard_old_password = true` to invalidate the old password
4. remove both options

What I confirmed while doing it:

- `mysql_user` is updated in place, so grants and existing connections are untouched.
- MySQL keeps only one secondary password, so a second rotation with `retain_current_password` invalidates the password retained by the first one.
- `DISCARD OLD PASSWORD` does not terminate existing connections. Only new connections fail, so an application with a warm connection pool can look healthy for a while after the discard.
- The discard takes effect immediately for new connections, so every consumer has to be updated before it runs. That is the part which needs care in an operational procedure, and it is why `has_secondary_password` is useful: it tells you whether the rotation is still half finished.

The state written by this branch was compatible with the released v0.4.2 for the two `auth_option` options, which v0.4.2 ignored and dropped on its next apply. `has_secondary_password` is `Computed` rather than optional, so that case is not verified yet.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for zero-downtime MySQL password rotation using dual passwords.
  - Added options to retain the current password during rotation or discard an old password afterward.
  - Added a read-only indicator showing whether a secondary password exists.
  - Added validation for unsupported MySQL versions and conflicting rotation settings.
  - Added an example configuration and check for detecting stale secondary passwords.

- **Documentation**
  - Documented staged password rotation, warnings, authentication options, and cleanup procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
