### PR TITLE
Harden error handling to prevent silent state loss and unwanted drops

### DIFF
--- a/internal/provider/database_resource.go
+++ b/internal/provider/database_resource.go
@@ -2,6 +2,8 @@ package provider
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -136,11 +138,15 @@ func (r *databaseResource) Read(ctx context.Context, req resource.ReadRequest, r
 	}
 
 	var characterSet, collation string
-	sql := "SELECT DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = ?"
-	err = db.QueryRowContext(ctx, sql, data.Id.ValueString()).Scan(&characterSet, &collation)
+	query := "SELECT DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = ?"
+	err = db.QueryRowContext(ctx, query, data.Id.ValueString()).Scan(&characterSet, &collation)
 	if err != nil {
-		tflog.Error(ctx, err.Error(), map[string]any{"sql": sql, "args": []interface{}{data.Id.ValueString()}})
-		resp.State.RemoveResource(ctx)
+		if errors.Is(err, sql.ErrNoRows) {
+			// The database is gone on the server, so remove it from the state.
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(fmt.Sprintf("Failed reading database (%s)", data.Id.ValueString()), err.Error())
 		return
 	}
 

--- a/internal/provider/database_resource_test.go
+++ b/internal/provider/database_resource_test.go
@@ -65,6 +65,32 @@ func TestAccDatabaseResource_ImportNonExistentRemoteObject(t *testing.T) {
 	})
 }
 
+// TestAccDatabaseResource_RemovedOutOfBand checks that a database dropped outside of
+// Terraform is removed from the state on refresh, instead of failing the refresh.
+func TestAccDatabaseResource_RemovedOutOfBand(t *testing.T) {
+	name := fmt.Sprintf("test-%04d", rand.Intn(10000))
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccDatabaseResource_CheckDestroy(name),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseResource_Config(name),
+			},
+			{
+				PreConfig: func() {
+					db := testDatabase()
+					if _, err := db.Exec(fmt.Sprintf("DROP DATABASE `%s`", name)); err != nil {
+						t.Fatalf("failed dropping database %s: %v", name, err)
+					}
+				},
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccDatabaseResource_Config(name string) string {
 	return fmt.Sprintf(`
 resource "mysql_database" "test" {

--- a/internal/provider/default_roles_resource.go
+++ b/internal/provider/default_roles_resource.go
@@ -123,7 +123,12 @@ func (r *DefaultRolesResource) Read(ctx context.Context, req resource.ReadReques
 
 	user := data.User.ValueString()
 	host := data.Host.ValueString()
-	if !utils.UserExists(ctx, db, user, host) {
+	exists, err := utils.UserExists(ctx, db, user, host)
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Failed checking whether the user exists (%s@%s)", user, host), err.Error())
+		return
+	}
+	if !exists {
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/default_roles_resource.go
+++ b/internal/provider/default_roles_resource.go
@@ -166,6 +166,12 @@ WHERE
 		roleValues["host"] = types.StringValue(roleHost)
 		defaultRoles = append(defaultRoles, types.ObjectValueMust(RoleTypes, roleValues))
 	}
+	// `rows.Next` returns false on an iteration failure as well, so check `rows.Err`
+	// before writing a possibly partial result to the state.
+	if err := rows.Err(); err != nil {
+		resp.Diagnostics.AddError("Failed reading MySQL rows", err.Error())
+		return
+	}
 	data.DefaultRoles = types.SetValueMust(types.ObjectType{AttrTypes: RoleTypes}, defaultRoles)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/global_variable_resource.go
+++ b/internal/provider/global_variable_resource.go
@@ -128,8 +128,14 @@ func (r *GlobalVariableResource) Read(ctx context.Context, req resource.ReadRequ
 	var value string
 	err = db.QueryRowContext(ctx, sql).Scan(&value)
 	if err != nil {
-		resp.Diagnostics.AddWarning("Failed scanning MySQL rows", err.Error())
-		resp.State.RemoveResource(ctx)
+		if mysqlErrorNumber(err) == unknownSystemVariableErrorNumber {
+			// The variable does not exist on the server (e.g. a plugin variable after
+			// the plugin was uninstalled), so remove it from the state.
+			resp.Diagnostics.AddWarning(fmt.Sprintf("Unknown system variable (%s)", name), err.Error())
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(fmt.Sprintf("Failed reading global variable (%s)", name), err.Error())
 		return
 	}
 	data.ID = types.StringValue(name)

--- a/internal/provider/grant_privilege_resource.go
+++ b/internal/provider/grant_privilege_resource.go
@@ -279,6 +279,12 @@ func (r *GrantPrivilegeResource) Read(ctx context.Context, req resource.ReadRequ
 			privileges = append(privileges, types.ObjectValueMust(PrivlilegeTypeModelTypes, privilegeTypeModelValue))
 		}
 	}
+	// `rows.Next` returns false on an iteration failure as well, so check `rows.Err`
+	// before writing a possibly partial result to the state.
+	if err := rows.Err(); err != nil {
+		resp.Diagnostics.AddError("Failed reading MySQL rows", err.Error())
+		return
+	}
 
 	tflog.Info(ctx, fmt.Sprintf("\nprivileges=%+v\n", privileges))
 
@@ -655,6 +661,11 @@ func checkGrantOption(ctx context.Context, db *sql.DB, privilegeLevel PrivilegeL
 		if grantPrivilege.Match(database, table, userName, hostName) && grantPrivilege.GrantOption {
 			return true, nil
 		}
+	}
+	// `rows.Next` returns false on an iteration failure as well, so report it instead
+	// of answering "no GRANT OPTION" for a transient error.
+	if err := rows.Err(); err != nil {
+		return false, err
 	}
 
 	return false, nil

--- a/internal/provider/grant_privilege_resource.go
+++ b/internal/provider/grant_privilege_resource.go
@@ -225,10 +225,14 @@ func (r *GrantPrivilegeResource) Read(ctx context.Context, req resource.ReadRequ
 
 	rows, err := db.QueryContext(ctx, sql, args...)
 	if err != nil {
+		if mysqlErrorNumber(err) == nonExistingGrantErrorNumber {
+			// The target user or role is gone on the server, so the grant is gone with it.
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Failed showing grants (%s@%s)", userOrRole.Name.ValueString(), userOrRole.Host.ValueString()),
 			err.Error())
-		resp.State.RemoveResource(ctx)
 		return
 	}
 	defer func() { _ = rows.Close() }()

--- a/internal/provider/grant_privilege_resource_test.go
+++ b/internal/provider/grant_privilege_resource_test.go
@@ -569,7 +569,34 @@ func TestAccGrantPrivilegeResource_ImportNonExistentRemoteObject(t *testing.T) {
 				ImportState:       true,
 				ImportStateId:     fmt.Sprintf("%s@*@non-existent-user@%%", database),
 				ImportStateVerify: false,
-				ExpectError:       regexp.MustCompile("Failed showing grants"),
+				ExpectError:       regexp.MustCompile("Cannot import non-existent remote object"),
+			},
+		},
+	})
+}
+
+// TestAccGrantPrivilegeResource_RemovedOutOfBand checks that a grant whose target user
+// was dropped outside of Terraform is removed from the state on refresh, instead of
+// failing the refresh with ER_NONEXISTING_GRANT.
+func TestAccGrantPrivilegeResource_RemovedOutOfBand(t *testing.T) {
+	database := fmt.Sprintf("test-db-%04d", rand.Intn(10000))
+	user := NewRandomUser("test-user", "%")
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGrantPrivilegeResource_Config(t, database, user.GetName(), []string{"SELECT"}, []string{}),
+			},
+			{
+				PreConfig: func() {
+					db := testDatabase()
+					if _, err := db.Exec(fmt.Sprintf("DROP USER '%s'@'%s'", user.GetName(), user.GetHost())); err != nil {
+						t.Fatalf("failed dropping user %s: %v", user.GetID(), err)
+					}
+				},
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/provider/grant_role_resource.go
+++ b/internal/provider/grant_role_resource.go
@@ -202,6 +202,12 @@ WHERE
 		currentRoles = append(currentRoles, types.ObjectValueMust(RoleTypes, attributes))
 		data.AdminOption = types.BoolValue(adminOption == "Y")
 	}
+	// `rows.Next` returns false on an iteration failure as well, so check `rows.Err`
+	// before writing a possibly partial result to the state.
+	if err := rows.Err(); err != nil {
+		resp.Diagnostics.AddError("Failed reading MySQL rows", err.Error())
+		return
+	}
 	data.Roles = types.SetValueMust(types.ObjectType{AttrTypes: RoleTypes}, currentRoles)
 
 	// Save updated data into Terraform state

--- a/internal/provider/grant_role_resource.go
+++ b/internal/provider/grant_role_resource.go
@@ -151,7 +151,14 @@ func (r *GrantRoleResource) Read(ctx context.Context, req resource.ReadRequest, 
 	args = append(args, userOrRole.Name.ValueString())
 	args = append(args, userOrRole.Host.ValueString())
 
-	if !utils.UserExists(ctx, db, userOrRole.Name.ValueString(), userOrRole.Host.ValueString()) {
+	exists, err := utils.UserExists(ctx, db, userOrRole.Name.ValueString(), userOrRole.Host.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Failed checking whether the user exists (%s@%s)", userOrRole.Name.ValueString(), userOrRole.Host.ValueString()),
+			err.Error())
+		return
+	}
+	if !exists {
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -383,6 +383,10 @@ func serverVersion(db *sql.DB) (*version.Version, error) {
 // See https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
 const unknownSystemVariableErrorNumber uint16 = 1193
 
+// nonExistingGrantErrorNumber is ER_NONEXISTING_GRANT, which `SHOW GRANTS FOR` reports
+// when the target user or role does not exist.
+const nonExistingGrantErrorNumber uint16 = 1141
+
 // 0 == not mysql error or not error at all.
 func mysqlErrorNumber(err error) uint16 {
 	if err == nil {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -333,10 +333,10 @@ func connectToMySQLInternal(ctx context.Context, conf *MySQLConfiguration) (*One
 	db.SetMaxOpenConns(conf.MaxOpenConns)
 
 	currentVersion, err := afterConnectVersion(ctx, db)
-	tflog.Info(ctx, currentVersion.String())
 	if err != nil {
 		return nil, fmt.Errorf("failed running after connect command: %v", err)
 	}
+	tflog.Info(ctx, currentVersion.String())
 
 	connectionCache[dsn] = &OneConnection{
 		Db:      db,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -379,6 +379,10 @@ func serverVersion(db *sql.DB) (*version.Version, error) {
 	return version.NewVersion(versionString)
 }
 
+// unknownSystemVariableErrorNumber is ER_UNKNOWN_SYSTEM_VARIABLE.
+// See https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
+const unknownSystemVariableErrorNumber uint16 = 1193
+
 // 0 == not mysql error or not error at all.
 func mysqlErrorNumber(err error) uint16 {
 	if err == nil {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"testing"
 	"time"
 
@@ -52,5 +53,18 @@ func testMySQLConfig() *MySQLConfiguration {
 		MaxConnLifetime:     time.Duration(8*60*60) * time.Second,
 		MaxOpenConns:        5,
 		ConnectRetryTimeout: time.Duration(300) * time.Second,
+	}
+}
+
+func TestMysqlErrorNumber(t *testing.T) {
+	t.Parallel()
+	if got := mysqlErrorNumber(&mysql.MySQLError{Number: 1193}); got != unknownSystemVariableErrorNumber {
+		t.Errorf("mysqlErrorNumber(MySQLError 1193): got %d, want %d", got, unknownSystemVariableErrorNumber)
+	}
+	if got := mysqlErrorNumber(fmt.Errorf("not a mysql error")); got != 0 {
+		t.Errorf("mysqlErrorNumber(non-MySQL error): got %d, want 0", got)
+	}
+	if got := mysqlErrorNumber(nil); got != 0 {
+		t.Errorf("mysqlErrorNumber(nil): got %d, want 0", got)
 	}
 }

--- a/internal/provider/role_resource.go
+++ b/internal/provider/role_resource.go
@@ -2,6 +2,8 @@ package provider
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -114,7 +116,7 @@ func (r *RoleResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	args = append(args, data.Name.ValueString())
 	args = append(args, data.Host.ValueString())
 
-	sql := `
+	query := `
 SELECT
   User
 , Host
@@ -126,16 +128,22 @@ WHERE
   AND authentication_string = ''
   AND password_expired = 'Y'
 `
-	tflog.Info(ctx, sql, map[string]any{"args": args})
+	tflog.Info(ctx, query, map[string]any{"args": args})
 
 	var name, host string
-	if err = db.QueryRowContext(ctx, sql, args...).Scan(&name, &host); err != nil {
-		resp.State.RemoveResource(ctx)
+	if err = db.QueryRowContext(ctx, query, args...).Scan(&name, &host); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			// The role is gone on the server, so remove it from the state.
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Failed reading role (%s@%s)", data.Name.ValueString(), data.Host.ValueString()),
+			err.Error())
 		return
-	} else {
-		data.Name = types.StringValue(name)
-		data.Host = types.StringValue(host)
 	}
+	data.Name = types.StringValue(name)
+	data.Host = types.StringValue(host)
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/role_resource_test.go
+++ b/internal/provider/role_resource_test.go
@@ -65,6 +65,32 @@ func TestAccRoleResource_ImportNonExistentRemoteObject(t *testing.T) {
 	})
 }
 
+// TestAccRoleResource_RemovedOutOfBand checks that a role dropped outside of Terraform
+// is removed from the state on refresh, instead of failing the refresh.
+func TestAccRoleResource_RemovedOutOfBand(t *testing.T) {
+	role := NewRandomRole("test-role", "%")
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccRoleResource_CheckDestroy([]RoleModel{role}),
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoleResource_Config(role.GetName()),
+			},
+			{
+				PreConfig: func() {
+					db := testDatabase()
+					if _, err := db.Exec(fmt.Sprintf("DROP ROLE '%s'@'%s'", role.GetName(), role.GetHost())); err != nil {
+						t.Fatalf("failed dropping role %s: %v", role.GetID(), err)
+					}
+				},
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccRoleResource_Config(name string) string {
 	return fmt.Sprintf(`
 resource "mysql_role" "test" {

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/go-sql-driver/mysql"
 	"github.com/hashicorp/go-version"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -379,8 +378,7 @@ WHERE
 		var defaultAuthenticationPlugin string
 		err := db.QueryRowContext(ctx, "SELECT @@default_authentication_plugin").Scan(&defaultAuthenticationPlugin)
 		if err != nil {
-			// Check if error is specifically about the unknown variable (MySQL 8.4+)
-			if mysqlErr, ok := err.(*mysql.MySQLError); ok && mysqlErr.Number == 1193 {
+			if mysqlErrorNumber(err) == unknownSystemVariableErrorNumber {
 				// ER_UNKNOWN_SYSTEM_VARIABLE: For MySQL 8.4+ where default_authentication_plugin is removed
 				// Default authentication plugin is caching_sha2_password
 				defaultAuthenticationPlugin = "caching_sha2_password"

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -404,6 +404,9 @@ WHERE
 	} else {
 		var authOption AuthOptionModel
 		resp.Diagnostics.Append(data.AuthOption.As(ctx, &authOption, basetypes.ObjectAsOptions{})...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 
 		attributes := map[string]attr.Value{}
 		attributes["plugin"] = types.StringNull()

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -339,7 +340,7 @@ func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	args = append(args, host)
 	args = append(args, user)
 
-	sql := fmt.Sprintf(`
+	query := fmt.Sprintf(`
 SELECT
   Host
 , User
@@ -353,70 +354,74 @@ WHERE
   Host = ?
   AND User = ?
 `, secondaryPasswordExpression(currentVersion))
-	tflog.Info(ctx, sql, map[string]any{"args": args})
+	tflog.Info(ctx, query, map[string]any{"args": args})
 	var _host, _user, plugin, authString, accountLocked string
 	var hasSecondaryPassword bool
-	if err = db.QueryRowContext(ctx, sql, args...).Scan(&_host, &_user, &plugin, &authString, &accountLocked, &hasSecondaryPassword); err != nil {
-		resp.State.RemoveResource(ctx)
+	if err = db.QueryRowContext(ctx, query, args...).Scan(&_host, &_user, &plugin, &authString, &accountLocked, &hasSecondaryPassword); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			// The user is gone on the server, so remove it from the state.
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(fmt.Sprintf("Failed reading user (%s@%s)", user, host), err.Error())
 		return
-	} else {
-		data.Name = types.StringValue(user)
-		data.Host = types.StringValue(host)
-		data.HasSecondaryPassword = types.BoolValue(hasSecondaryPassword)
-		data.Lock = types.BoolValue(accountLocked == "Y")
+	}
+	data.Name = types.StringValue(user)
+	data.Host = types.StringValue(host)
+	data.HasSecondaryPassword = types.BoolValue(hasSecondaryPassword)
+	data.Lock = types.BoolValue(accountLocked == "Y")
 
-		if data.AuthOption.IsNull() {
-			// https://dev.mysql.com/doc/refman/8.4/en/native-pluggable-authentication.html
-			// The mysql_native_password authentication plugin is deprecated as of MySQL 8.0.34, disabled by default in MySQL 8.4,
-			// and removed as of MySQL 9.0.0.
-			// See https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_default_authentication_plugin
-			var defaultAuthenticationPlugin string
-			err := db.QueryRowContext(ctx, "SELECT @@default_authentication_plugin").Scan(&defaultAuthenticationPlugin)
-			if err != nil {
-				// Check if error is specifically about the unknown variable (MySQL 8.4+)
-				if mysqlErr, ok := err.(*mysql.MySQLError); ok && mysqlErr.Number == 1193 {
-					// ER_UNKNOWN_SYSTEM_VARIABLE: For MySQL 8.4+ where default_authentication_plugin is removed
-					// Default authentication plugin is caching_sha2_password
-					defaultAuthenticationPlugin = "caching_sha2_password"
-					tflog.Info(ctx, fmt.Sprintf("Using hardcoded default plugin for MySQL 8.4+: %s", defaultAuthenticationPlugin))
-				} else {
-					// Other database errors should be surfaced
-					resp.Diagnostics.AddError("Failed to query default authentication plugin", err.Error())
-					return
-				}
+	if data.AuthOption.IsNull() {
+		// https://dev.mysql.com/doc/refman/8.4/en/native-pluggable-authentication.html
+		// The mysql_native_password authentication plugin is deprecated as of MySQL 8.0.34, disabled by default in MySQL 8.4,
+		// and removed as of MySQL 9.0.0.
+		// See https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_default_authentication_plugin
+		var defaultAuthenticationPlugin string
+		err := db.QueryRowContext(ctx, "SELECT @@default_authentication_plugin").Scan(&defaultAuthenticationPlugin)
+		if err != nil {
+			// Check if error is specifically about the unknown variable (MySQL 8.4+)
+			if mysqlErr, ok := err.(*mysql.MySQLError); ok && mysqlErr.Number == 1193 {
+				// ER_UNKNOWN_SYSTEM_VARIABLE: For MySQL 8.4+ where default_authentication_plugin is removed
+				// Default authentication plugin is caching_sha2_password
+				defaultAuthenticationPlugin = "caching_sha2_password"
+				tflog.Info(ctx, fmt.Sprintf("Using hardcoded default plugin for MySQL 8.4+: %s", defaultAuthenticationPlugin))
 			} else {
-				tflog.Info(ctx, fmt.Sprintf("default_authentication_plugin=%s", defaultAuthenticationPlugin))
-			}
-			if plugin != defaultAuthenticationPlugin {
-				attributes := map[string]attr.Value{
-					"plugin":                  types.StringValue(plugin),
-					"auth_string":             types.StringNull(),
-					"random_password":         types.BoolNull(),
-					"retain_current_password": types.BoolNull(),
-					"discard_old_password":    types.BoolNull(),
-				}
-				data.AuthOption = types.ObjectValueMust(AuthOptionModelTypes, attributes)
+				// Other database errors should be surfaced
+				resp.Diagnostics.AddError("Failed to query default authentication plugin", err.Error())
+				return
 			}
 		} else {
-			var authOption AuthOptionModel
-			resp.Diagnostics.Append(data.AuthOption.As(ctx, &authOption, basetypes.ObjectAsOptions{})...)
-
-			attributes := map[string]attr.Value{}
-			attributes["plugin"] = types.StringNull()
-			if !authOption.Plugin.IsNull() {
-				attributes["plugin"] = types.StringValue(plugin)
+			tflog.Info(ctx, fmt.Sprintf("default_authentication_plugin=%s", defaultAuthenticationPlugin))
+		}
+		if plugin != defaultAuthenticationPlugin {
+			attributes := map[string]attr.Value{
+				"plugin":                  types.StringValue(plugin),
+				"auth_string":             types.StringNull(),
+				"random_password":         types.BoolNull(),
+				"retain_current_password": types.BoolNull(),
+				"discard_old_password":    types.BoolNull(),
 			}
-			attributes["auth_string"] = types.StringNull()
-			if !authOption.AuthString.IsNull() {
-				attributes["auth_string"] = authOption.AuthString
-			}
-			attributes["random_password"] = authOption.RandomPassword
-			// The dual password options are write-only options for `ALTER USER`, so keep the configured values.
-			attributes["retain_current_password"] = authOption.RetainCurrentPassword
-			attributes["discard_old_password"] = authOption.DiscardOldPassword
-
 			data.AuthOption = types.ObjectValueMust(AuthOptionModelTypes, attributes)
 		}
+	} else {
+		var authOption AuthOptionModel
+		resp.Diagnostics.Append(data.AuthOption.As(ctx, &authOption, basetypes.ObjectAsOptions{})...)
+
+		attributes := map[string]attr.Value{}
+		attributes["plugin"] = types.StringNull()
+		if !authOption.Plugin.IsNull() {
+			attributes["plugin"] = types.StringValue(plugin)
+		}
+		attributes["auth_string"] = types.StringNull()
+		if !authOption.AuthString.IsNull() {
+			attributes["auth_string"] = authOption.AuthString
+		}
+		attributes["random_password"] = authOption.RandomPassword
+		// The dual password options are write-only options for `ALTER USER`, so keep the configured values.
+		attributes["retain_current_password"] = authOption.RetainCurrentPassword
+		attributes["discard_old_password"] = authOption.DiscardOldPassword
+
+		data.AuthOption = types.ObjectValueMust(AuthOptionModelTypes, attributes)
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -283,11 +283,13 @@ func (r *UserResource) Create(ctx context.Context, req resource.CreateRequest, r
 		_, err = db.ExecContext(ctx, sql, args...)
 		if err != nil {
 			resp.Diagnostics.AddError("Failed creating user", err.Error())
+			return
 		}
 	} else {
 		rows, err := db.QueryContext(ctx, sql, args...)
 		if err != nil {
 			resp.Diagnostics.AddError("Failed creating user", err.Error())
+			return
 		}
 		defer func() { _ = rows.Close() }()
 		for rows.Next() {

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -245,6 +245,9 @@ func (r *UserResource) Create(ctx context.Context, req resource.CreateRequest, r
 	if !data.AuthOption.IsNull() {
 		var authOption *AuthOptionModel
 		resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("auth_option"), &authOption)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 		if authOption.RetainCurrentPassword.ValueBool() || authOption.DiscardOldPassword.ValueBool() {
 			resp.Diagnostics.AddWarning(
 				"Ignored dual password options on creating user",
@@ -452,6 +455,9 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	if !data.AuthOption.IsNull() {
 		var authOption *AuthOptionModel
 		resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("auth_option"), &authOption)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 		discardOldPassword = authOption.DiscardOldPassword.ValueBool()
 		// `ValidateConfig` sees an unknown value as false, so repeat the check on the resolved
 		// values. Without it the statement would retain the current password and the following

--- a/internal/provider/user_resource_test.go
+++ b/internal/provider/user_resource_test.go
@@ -579,6 +579,33 @@ func TestAccUserResource_CreateFailsOnExistingUser(t *testing.T) {
 	}
 }
 
+// TestAccUserResource_RemovedOutOfBand checks that a user dropped outside of Terraform
+// is removed from the state on refresh, instead of failing the refresh.
+func TestAccUserResource_RemovedOutOfBand(t *testing.T) {
+	user := NewRandomUser("test-user", "%")
+	t.Logf("%+v\n", user)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccUserResource_CheckDestroy([]UserModel{user}),
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserResource_Config(t, user.GetName(), ""),
+			},
+			{
+				PreConfig: func() {
+					db := testDatabase()
+					if _, err := db.Exec(fmt.Sprintf("DROP USER '%s'@'%s'", user.GetName(), user.GetHost())); err != nil {
+						t.Fatalf("failed dropping user %s: %v", user.GetID(), err)
+					}
+				},
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccUserResource_Config(t *testing.T, name, host string) string {
 	source := `
 resource "mysql_user" "test" {

--- a/internal/provider/user_resource_test.go
+++ b/internal/provider/user_resource_test.go
@@ -550,6 +550,14 @@ func TestAccUserResource_CreateFailsOnExistingUser(t *testing.T) {
 	user := NewRandomUser("test-user", "%")
 	t.Logf("%+v\n", user)
 	config := testAccUserResource_Config(t, user.GetName(), "")
+	// The conflicting user is created outside of Terraform below, so it must be dropped
+	// regardless of how resource.Test exits (including via t.Fatal on failure paths).
+	t.Cleanup(func() {
+		db := testDatabase()
+		if _, err := db.Exec(fmt.Sprintf("DROP USER IF EXISTS '%s'@'%s'", user.GetName(), user.GetHost())); err != nil {
+			t.Errorf("failed dropping the conflicting user %s: %v", user.GetID(), err)
+		}
+	})
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -572,11 +580,6 @@ func TestAccUserResource_CreateFailsOnExistingUser(t *testing.T) {
 			},
 		},
 	})
-	// The conflicting user was created outside of Terraform, so drop it here.
-	db := testDatabase()
-	if _, err := db.Exec(fmt.Sprintf("DROP USER IF EXISTS '%s'@'%s'", user.GetName(), user.GetHost())); err != nil {
-		t.Errorf("failed dropping the conflicting user %s: %v", user.GetID(), err)
-	}
 }
 
 // TestAccUserResource_RemovedOutOfBand checks that a user dropped outside of Terraform

--- a/internal/provider/user_resource_test.go
+++ b/internal/provider/user_resource_test.go
@@ -542,6 +542,43 @@ func TestAccUserResource_ImportNonExistentRemoteObject(t *testing.T) {
 	})
 }
 
+// TestAccUserResource_CreateFailsOnExistingUser checks that a failed create does not
+// record the resource in the state. Before the fix the failed create was recorded as
+// tainted, so the next apply planned a replace and DROPped the pre-existing user,
+// which Terraform does not manage.
+func TestAccUserResource_CreateFailsOnExistingUser(t *testing.T) {
+	user := NewRandomUser("test-user", "%")
+	t.Logf("%+v\n", user)
+	config := testAccUserResource_Config(t, user.GetName(), "")
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					db := testDatabase()
+					if _, err := db.Exec(fmt.Sprintf("CREATE USER '%s'@'%s'", user.GetName(), user.GetHost())); err != nil {
+						t.Fatalf("failed creating the conflicting user %s: %v", user.GetID(), err)
+					}
+				},
+				Config:      config,
+				ExpectError: regexp.MustCompile("Failed creating user"),
+			},
+			// The second apply must fail with the same error. Before the fix it silently
+			// succeeded, because the tainted resource was replaced by DROP + CREATE.
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile("Failed creating user"),
+			},
+		},
+	})
+	// The conflicting user was created outside of Terraform, so drop it here.
+	db := testDatabase()
+	if _, err := db.Exec(fmt.Sprintf("DROP USER IF EXISTS '%s'@'%s'", user.GetName(), user.GetHost())); err != nil {
+		t.Errorf("failed dropping the conflicting user %s: %v", user.GetID(), err)
+	}
+}
+
 func testAccUserResource_Config(t *testing.T, name, host string) string {
 	source := `
 resource "mysql_user" "test" {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"os"
-	"strconv"
-
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 func GetenvWithDefault(key, defaultValue string) string {
@@ -17,16 +14,12 @@ func GetenvWithDefault(key, defaultValue string) string {
 	}
 }
 
-func UserExists(ctx context.Context, db *sql.DB, user, host string) bool {
-	var count string
+// UserExists reports whether the user exists on the server. The error is returned as is,
+// so that the caller can distinguish a missing user from a failed query.
+func UserExists(ctx context.Context, db *sql.DB, user, host string) (bool, error) {
+	var count int64
 	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM mysql.user WHERE User = ? AND Host = ?", user, host).Scan(&count); err != nil {
-		tflog.Error(ctx, err.Error())
-		return false
+		return false, err
 	}
-	if c, err := strconv.ParseInt(count, 10, 64); err != nil {
-		tflog.Error(ctx, err.Error())
-		return false
-	} else {
-		return c > 0
-	}
+	return count > 0, nil
 }


### PR DESCRIPTION
## Summary
- `Read` in every resource treated *any* query error (transient connection failures, permission errors) as "the object is gone" and silently removed the resource from the state, so the next apply planned a fresh create — or worse. This PR distinguishes "genuinely gone" from "the query failed" across all resources.
- `Create` in `mysql_user` saved the state even when `CREATE USER` failed (e.g. ERROR 1396 on a name collision with an unmanaged account). The failed apply recorded a tainted resource, and the next apply planned a replace that `DROP USER`ed the pre-existing, unmanaged account. `Create` now returns without saving state on failure, so the next apply simply retries and fails with the same error.
- Fixes a provider crash (nil pointer dereference) when reading the server version fails right after connecting, plus two missing diagnostics checks that could panic instead of reporting an error.

## Changes
- `mysql_user`, `mysql_role`, `mysql_database`: remove the resource from state only on `sql.ErrNoRows`; surface every other error as a diagnostic.
- `mysql_global_variable`: classify `ER_UNKNOWN_SYSTEM_VARIABLE` (1193) as "variable is gone" via a named constant; surface other errors. The same constant replaces the duplicated 1193 check in `mysql_user`'s `default_authentication_plugin` fallback.
- `mysql_grant_privilege`: classify `ER_NONEXISTING_GRANT` (1141) as "grant target is gone" and remove the resource; previously the code both reported an error *and* removed the resource, so refreshing after the target user was dropped failed instead of planning a recreate. Importing a non-existent grant now reports the framework's standard "Cannot import non-existent remote object", consistent with the other resources.
- `mysql_default_roles`, `mysql_grant_role`: `utils.UserExists` now returns `(bool, error)` instead of logging failures and returning `false`, so both callers report query errors instead of silently dropping the resource.
- `mysql_user` `Create`: return immediately when `CREATE USER` fails instead of saving the state.
- Provider: log the server version only after checking the error from the version query (nil deref fix); check diagnostics after `GetAttribute` before dereferencing `auth_option` in `Create`/`Update`.

## Behavior change
Refreshes that previously "self-healed" by silently dropping a resource from the state on any error (including transient ones) now report the error instead. This is strictly safer, but practitioners may see refresh errors where state entries used to disappear silently.

## Testing
- New acceptance tests:
  - `TestAccUserResource_CreateFailsOnExistingUser` reproduces the tainted-replace `DROP` hazard (red before the fix, green after).
  - `TestAccGrantPrivilegeResource_RemovedOutOfBand` reproduces the refresh failure after the grant target is dropped out of band (red before, green after).
  - `TestAccUserResource_RemovedOutOfBand`, `TestAccRoleResource_RemovedOutOfBand`, `TestAccDatabaseResource_RemovedOutOfBand` pin the "genuinely gone → removed from state" behavior as regression guards.
  - `TestMysqlErrorNumber` unit test for the error-number classification helper.
- Full suite verified locally: `go build` / `go vet` clean, unit tests 20/20, acceptance tests 54/54 against both MySQL 8.0 and MySQL 8.4, and `go generate ./...` produces no diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved refresh behavior when databases, roles, users, or grants are removed outside Terraform.
  * Resources now remain in state when refresh encounters unexpected database errors.
  * Added clearer diagnostics for failed queries, user checks, and result processing.
  * Improved handling of unknown system variables, missing remote objects, and conflicting user creation.
  * Prevented misleading connection logs when version detection fails.
  * Improved authentication option validation and state updates for users.
* **Tests**
  * Added coverage for out-of-band deletions, failed user creation, imports, and database error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->